### PR TITLE
allow simple fields

### DIFF
--- a/lib/elasticity/document.rb
+++ b/lib/elasticity/document.rb
@@ -86,9 +86,8 @@ module Elasticity
 
     # Creates a instance of a document from a ElasticSearch hit data.
     def self.from_hit(hit_data)
-      attrs = {}
+      attrs = { _id: hit_data["_id"] }
       attrs.merge!(hit_data["_source"]) if hit_data["_source"]
-      attrs.merge!({ _id: hit_data["_id"] }) if hit_data["_id"]
 
       if hit_data["highlight"]
         highlighted_attrs = attrs.dup

--- a/lib/elasticity/document.rb
+++ b/lib/elasticity/document.rb
@@ -86,7 +86,9 @@ module Elasticity
 
     # Creates a instance of a document from a ElasticSearch hit data.
     def self.from_hit(hit_data)
-      attrs = hit_data["_source"].merge(_id: hit_data['_id'])
+      attrs = {}
+      attrs.merge!(hit_data["_source"]) if hit_data["_source"]
+      attrs.merge!({ _id: hit_data["_id"] }) if hit_data["_id"]
 
       if hit_data["highlight"]
         highlighted_attrs = attrs.dup

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = "0.3.3"
+  VERSION = "0.3.4"
 end

--- a/spec/units/document_spec.rb
+++ b/spec/units/document_spec.rb
@@ -77,6 +77,12 @@ RSpec.describe Elasticity::Document do
       expect(strategy).to receive(:delete_document).with("class_name", 1).and_return(strategy_ret)
       expect(subject.delete(1)).to eq strategy_ret
     end
+
+    it "properly instantiates from search hit when no source is given" do
+      hit = { "_id" => 1, "_type" => "foo" }
+      doc = subject.from_hit(hit)
+      expect(doc._id).to eq(1)
+    end
   end
 
   context "instance" do


### PR DESCRIPTION
currently if you try and run a query that has fields: [] in it, a nil.merge method will be thrown.  This handles that case by building the hash more cautiously.  