### PR TITLE
Mappings & Settings API Response

### DIFF
--- a/elasticity.gemspec
+++ b/elasticity.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activesupport", "~> 4.0"
   spec.add_dependency "activemodel",   "~> 4.0"
-  spec.add_dependency "elasticsearch", "~> 1.0.5"
+  spec.add_dependency "elasticsearch", "~> 1.0.12"
 end

--- a/lib/elasticity/document.rb
+++ b/lib/elasticity/document.rb
@@ -27,7 +27,7 @@ module Elasticity
         index_base_name = "#{namespace}_#{@config.index_base_name}"
       end
 
-      @strategy = @config.strategy.new(Elasticity.config.client, index_base_name)
+      @strategy = @config.strategy.new(Elasticity.config.client, index_base_name, document_type)
     end
 
     # Document type

--- a/lib/elasticity/strategies.rb
+++ b/lib/elasticity/strategies.rb
@@ -4,8 +4,8 @@ module Elasticity
       attr_reader :index_base_name
 
       def initialize(index_base_name, message)
-        @index_name = index_name
-        super("#{index_name}: #{message}")
+        @index_base_name = index_base_name
+        super("#{index_base_name}: #{message}")
       end
     end
 

--- a/lib/elasticity/strategies/alias_index.rb
+++ b/lib/elasticity/strategies/alias_index.rb
@@ -6,10 +6,11 @@ module Elasticity
     class AliasIndex
       STATUSES = [:missing, :ok]
 
-      def initialize(client, index_base_name)
+      def initialize(client, index_base_name, document_type)
         @client       = client
         @main_alias   = index_base_name
         @update_alias = "#{index_base_name}_update"
+        @document_type = document_type
       end
 
       def ref_index_name
@@ -231,17 +232,13 @@ module Elasticity
       end
 
       def settings
-        args = { index: @main_alias }
-        settings = @client.index_get_settings(index: @main_alias)
-        settings[@main_alias]["settings"]
+        @client.index_get_settings(index: @main_alias, type: @document_type).values.first
       rescue Elasticsearch::Transport::Transport::Errors::NotFound
         nil
       end
 
       def mappings
-        args = { index: @main_alias }
-        mapping = @client.index_get_mapping(index: @main_alias)
-        mapping[@main_alias]["mappings"]
+        @client.index_get_mapping(index: @main_alias, type: @document_type).values.first
       rescue Elasticsearch::Transport::Transport::Errors::NotFound
         nil
       end

--- a/lib/elasticity/strategies/single_index.rb
+++ b/lib/elasticity/strategies/single_index.rb
@@ -3,9 +3,10 @@ module Elasticity
     class SingleIndex
       STATUSES = [:missing, :ok]
 
-      def initialize(client, index_name)
-        @client     = client
-        @index_name = index_name
+      def initialize(client, index_name, document_type)
+        @client        = client
+        @index_name    = index_name
+        @document_type = document_type
       end
 
       def ref_index_name
@@ -78,17 +79,13 @@ module Elasticity
       end
 
       def settings
-        args = { index: @index_name }
-        settings = @client.index_get_settings(index: @index_name)
-        settings[@index_name]["settings"]
+        @client.index_get_settings(index: @index_name, type: @document_type).values.first
       rescue Elasticsearch::Transport::Transport::Errors::NotFound
         nil
       end
 
       def mappings
-        args = { index: @index_name }
-        mapping = @client.index_get_mapping(index: @index_name)
-        mapping[@index_name]["mappings"]
+        @client.index_get_mapping(index: @index_name, type: @document_type).values.first
       rescue Elasticsearch::Transport::Transport::Errors::NotFound
         nil
       end

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = "0.3.6"
+  VERSION = "0.3.7"
 end

--- a/spec/units/strategies/single_index_spec.rb
+++ b/spec/units/strategies/single_index_spec.rb
@@ -1,14 +1,14 @@
 RSpec.describe Elasticity::Strategies::SingleIndex, elasticsearch: true do
   subject do
-    described_class.new(Elasticity.config.client, "test_index_name")
+    described_class.new(Elasticity.config.client, "test_index_name", "document")
   end
 
   let :index_def do
     {
-      mappings: {
-        document: {
-          properties: {
-            name: { type: "string" }
+      "mappings" => {
+        "document" => {
+          "properties" => {
+            "name" => { "type" => "string" }
           }
         }
       }
@@ -21,10 +21,10 @@ RSpec.describe Elasticity::Strategies::SingleIndex, elasticsearch: true do
 
   it "allows creating, recreating and deleting an index" do
     subject.create(index_def)
-    expect(subject.mappings).to eq({"document"=>{"properties"=>{"name"=>{"type"=>"string"}}}})
+    expect(subject.mappings).to eq(index_def)
 
     subject.recreate(index_def)
-    expect(subject.mappings).to eq({"document"=>{"properties"=>{"name"=>{"type"=>"string"}}}})
+    expect(subject.mappings).to eq(index_def)
 
     subject.delete
     expect(subject.mappings).to be nil


### PR DESCRIPTION
Enable mappings and settings responses to mimic the JSON that would be
sent to the create index API.

1. [FIXED] `document_type` was not specified when fetching mappings and
settings and should be specified until this gem supports multiple
document types per index.

2. [FIXED] Fetching mappings and settings fails as the root node
returned from the API might not be the `index_name` due to aliases.

3. Updated elasticsearch gem to v1.0.12. Refer to [changelog](https://github.com/elastic/elasticsearch-ruby/blob/master/CHANGELOG.md#1012).