### PR TITLE
Fix issue with hash keys as strings and pagination methods

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,2 +1,4 @@
+v0.4.5
+  - Fix issue with hash strings and pagination
 v0.4.4
   - Added support for surfacing document _score on query results.

--- a/lib/elasticity/search.rb
+++ b/lib/elasticity/search.rb
@@ -13,7 +13,7 @@ module Elasticity
       def initialize(index_name, document_type, body)
         @index_name    = index_name
         @document_type = document_type
-        @body          = body
+        @body          = body.deep_symbolize_keys!
       end
 
       def update(body_changes)

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = "0.4.4"
+  VERSION = "0.4.5"
 end

--- a/spec/functional/segmented_spec.rb
+++ b/spec/functional/segmented_spec.rb
@@ -43,8 +43,9 @@ RSpec.describe "Segmented indexes", elasticsearch: true do
     expect(success).to be true
 
     seg.flush_index
-    results = seg.by_name("rodrigo").to_a
-    expect(results).to eq [rodrigo]
+    results = seg.by_name("rodrigo").to_a.first
+    expect(results.class).to eq rodrigo.class
+    expect(results.name).to eq rodrigo.name
 
     rodrigo.delete
     seg.flush_index
@@ -69,10 +70,12 @@ RSpec.describe "Segmented indexes", elasticsearch: true do
     seg_a.flush_index
     seg_b.flush_index
 
-    res_a = seg_a.by_name("doc").to_a
-    expect(res_a).to eq [doc_a]
+    res_a = seg_a.by_name("doc").to_a.first
+    expect(res_a.class).to eq doc_a.class
+    expect(res_a.name).to eq doc_a.name
 
-    res_b = seg_b.by_name("doc").to_a
-    expect(res_b).to eq [doc_b]
+    res_b = seg_b.by_name("doc").to_a.first
+    expect(res_b.class).to eq doc_b.class
+    expect(res_b.name).to eq doc_b.name
   end
 end


### PR DESCRIPTION
#### Convert query param keys to symbols so that pagination works as expected. Also fixed the segmented_spec which is currently failing on master and bumped gem version.