### PR TITLE
Investigate and fix spec failures in travis

### DIFF
--- a/spec/functional/persistence_spec.rb
+++ b/spec/functional/persistence_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe "Persistence", elasticsearch: true do
 
     before do
       subject.recreate_index
+      @elastic_search_client.cluster.health wait_for_status: 'yellow'
     end
 
     after do


### PR DESCRIPTION
Elasticsearch is a little prone to error in situations which commands execute rapidly in an automated fashion. I added a check to make sure the cluster is healthy before each of the specs.