### PR TITLE
paginated multi search

### DIFF
--- a/lib/elasticity/multi_search.rb
+++ b/lib/elasticity/multi_search.rb
@@ -1,6 +1,5 @@
 module Elasticity
   class MultiSearch
-    include Enumerable
 
     def initialize
       @searches = {}
@@ -28,10 +27,6 @@ module Elasticity
       results_collection[name]
     end
 
-    def each(&block)
-      @searches.keys.map { |key| self[key] }.each(&block)
-    end
-
     private
 
     def results_collection
@@ -56,7 +51,7 @@ module Elasticity
         when search[:documents]
           Search::Results.new(resp, bodies[idx], search[:documents].method(:map_hit))
         when search[:active_records]
-          Search::ActiveRecordProxy.from_hits(search[:active_records], bodies[idx], resp)
+          Search::ActiveRecordProxy.map_response(search[:active_records], bodies[idx], resp)
         end
       end
 

--- a/lib/elasticity/multi_search.rb
+++ b/lib/elasticity/multi_search.rb
@@ -51,7 +51,7 @@ module Elasticity
         when search[:documents]
           Search::Results.new(resp, search[:search_definition].body, search[:documents].method(:map_hit))
         when search[:active_records]
-          Search::ActiveRecordProxy.map_response(search[:active_records], search[:search_definition], resp)
+          Search::ActiveRecordProxy.map_response(search[:active_records], search[:search_definition].body, resp)
         end
       end
 

--- a/lib/elasticity/multi_search.rb
+++ b/lib/elasticity/multi_search.rb
@@ -49,9 +49,9 @@ module Elasticity
 
         results[name] = case
         when search[:documents]
-          Search::Results.new(resp, bodies[idx], search[:documents].method(:map_hit))
+          Search::Results.new(resp, search[:search_definition].body, search[:documents].method(:map_hit))
         when search[:active_records]
-          Search::ActiveRecordProxy.map_response(search[:active_records], bodies[idx], resp)
+          Search::ActiveRecordProxy.map_response(search[:active_records], search[:search_definition], resp)
         end
       end
 

--- a/lib/elasticity/search.rb
+++ b/lib/elasticity/search.rb
@@ -186,15 +186,15 @@ module Elasticity
     end
 
     class ActiveRecordProxy
-      def self.map_response(relation, search_definition, response)
+      def self.map_response(relation, body, response)
         ids = response["hits"]["hits"].map { |hit| hit["_id"] }
 
         if ids.any?
           id_col  = "#{relation.connection.quote_column_name(relation.table_name)}.#{relation.connection.quote_column_name(relation.klass.primary_key)}"
           id_vals = ids.map { |id| relation.connection.quote(id) }
-          Relation.new(relation.where("#{id_col} IN (?)", ids).order("FIELD(#{id_col}, #{id_vals.join(',')})"), search_definition, response)
+          Relation.new(relation.where("#{id_col} IN (?)", ids).order("FIELD(#{id_col}, #{id_vals.join(',')})"), body, response)
         else
-          Relation.new(relation.none, search_definition, response)
+          Relation.new(relation.none, body, response)
         end
       end
 
@@ -254,7 +254,7 @@ module Elasticity
 
       def filtered_relation
         return @filtered_relation if defined?(@filtered_relation)
-        @filtered_relation = ActiveRecordProxy.map_response(@relation, @search_definition, response)
+        @filtered_relation = ActiveRecordProxy.map_response(@relation, @search_definition.body, response)
       end
     end
 

--- a/lib/elasticity/search.rb
+++ b/lib/elasticity/search.rb
@@ -84,11 +84,10 @@ module Elasticity
     class LazySearch
       include Enumerable
 
-      delegate :each, :size, :length, :[], :+, :-, :&, :|, to: :search_results
+      delegate :each, :size, :length, :[], :+, :-, :&, :|, :total, :per_page,
+        :total_pages, :current_page, to: :search_results
 
       attr_accessor :search_definition
-
-      DEFAULT_SIZE = 10
 
       def initialize(client, search_definition, &mapper)
         @client            = client
@@ -104,10 +103,6 @@ module Elasticity
         empty?
       end
 
-      def total
-        response["hits"]["total"]
-      end
-
       def aggregations
         response["aggregations"] ||= {}
       end
@@ -121,31 +116,7 @@ module Elasticity
       end
 
       def search_results
-        return @search_results if defined?(@search_results)
-
-        hits = response["hits"]["hits"]
-
-        @search_results = if @mapper.nil?
-          hits
-        else
-          hits.map { |hit| @mapper.(hit) }
-        end
-      end
-
-      # for pagination
-      def per_page
-        @search_definition.body[:size] || DEFAULT_SIZE
-      end
-
-      # for pagination
-      def total_pages
-        (total.to_f / per_page.to_f).ceil
-      end
-
-      # for pagination
-      def current_page
-        return 1 if @search_definition.body[:from].nil?
-        @search_definition.body[:from] / per_page + 1
+        @search_results ||= Search::Results.new(response, @search_definition, @mapper)
       end
 
       private
@@ -199,10 +170,9 @@ module Elasticity
 
           loop do
             response = @client.scroll(scroll_id: response["_scroll_id"], scroll: @scroll)
-            hits     = response["hits"]["hits"]
-            break if hits.empty?
+            break if response["hits"]["hits"].empty?
 
-            y << hits.map { |hit| @mapper.(hit) }
+            y << Search::Results.new(response, @search_definition, @mapper)
           end
         end
       end
@@ -216,21 +186,25 @@ module Elasticity
     end
 
     class ActiveRecordProxy
-      def self.from_hits(relation, hits)
-        ids = hits.map { |hit| hit["_id"] }
+      def self.from_hits(relation, search_definition, response)
+        relation
+        ids = response["hits"]["hits"].map { |hit| hit["_id"] }
 
         if ids.any?
           id_col  = "#{relation.connection.quote_column_name(relation.table_name)}.#{relation.connection.quote_column_name(relation.klass.primary_key)}"
           id_vals = ids.map { |id| relation.connection.quote(id) }
-          relation.where("#{id_col} IN (?)", ids).order("FIELD(#{id_col}, #{id_vals.join(',')})")
+          Relation.new(relation.where("#{id_col} IN (?)", ids).order("FIELD(#{id_col}, #{id_vals.join(',')})"), search_definition, response)
         else
-          relation.none
+          Relation.new(relation.none, search_definition, response)
         end
       end
 
       class Relation < ActiveSupport::ProxyObject
-        def initialize(relation)
+        DEFAULT_SIZE = 10
+
+        def initialize(relation, search_definition, response)
           @relation = relation
+          @search_definition = search_definition
         end
 
         def method_missing(name, *args, &block)
@@ -243,6 +217,26 @@ module Elasticity
           end
         end
 
+        def total
+          response["hits"]["total"]
+        end
+
+        # for pagination
+        def per_page
+          @search_definition.body[:size] || DEFAULT_SIZE
+        end
+
+        # for pagination
+        def total_pages
+          (total.to_f / per_page.to_f).ceil
+        end
+
+        # for pagination
+        def current_page
+          return 1 if @search_definition.body[:from].nil?
+          @search_definition.body[:from] / per_page + 1
+        end
+
         def inspect
           "#<#{self.class}: #{@relation.to_sql}>"
         end
@@ -251,7 +245,7 @@ module Elasticity
       def initialize(client, search_definition, relation)
         @client            = client
         @search_definition = search_definition.update(_source: false)
-        @relation          = Relation.new(relation)
+        @relation          = relation
       end
 
       def metadata
@@ -278,7 +272,7 @@ module Elasticity
 
       def filtered_relation
         return @filtered_relation if defined?(@filtered_relation)
-        @filtered_relation = ActiveRecordProxy.from_hits(@relation, response["hits"]["hits"])
+        @filtered_relation = ActiveRecordProxy.from_hits(@relation, @search_definition, response)
       end
     end
 
@@ -300,6 +294,48 @@ module Elasticity
 
       def method_missing(method_name, *args, &block)
         documents.public_send(method_name, *args, &block)
+      end
+    end
+
+    class Results
+      include Enumerable
+
+      delegate :each, :size, :length, :[], :+, :-, :&, :|, to: :@documents
+
+      DEFAULT_SIZE = 10
+
+      def initialize(response, search_definition, mapper = nil)
+        @response = response
+        @search_definition = search_definition
+        @documents = if mapper.nil?
+          @response["hits"]["hits"]
+        else
+          @response["hits"]["hits"].map { |hit| mapper.(hit) }
+        end
+      end
+
+      def each(&block)
+        @documents.each(&block)
+      end
+
+      def total
+        @response["hits"]["total"]
+      end
+
+      # for pagination
+      def per_page
+        @search_definition.body[:size] || DEFAULT_SIZE
+      end
+
+      # for pagination
+      def total_pages
+        (total.to_f / per_page.to_f).ceil
+      end
+
+      # for pagination
+      def current_page
+        return 1 if @search_definition.body[:from].nil?
+        @search_definition.body[:from] / per_page + 1
       end
     end
   end

--- a/lib/elasticity/search.rb
+++ b/lib/elasticity/search.rb
@@ -279,8 +279,8 @@ module Elasticity
       end
     end
 
-    class Results
-      include Enumerable
+    class Results < ActiveSupport::ProxyObject
+      include ::Enumerable
 
       delegate :each, :size, :length, :[], :+, :-, :&, :|, to: :@documents
 
@@ -294,6 +294,10 @@ module Elasticity
         else
           @response["hits"]["hits"].map { |hit| mapper.(hit) }
         end
+      end
+
+      def method_missing(name, *args, &block)
+        @documents.public_send(name, *args, &block)
       end
 
       def each(&block)

--- a/lib/elasticity/search.rb
+++ b/lib/elasticity/search.rb
@@ -116,7 +116,7 @@ module Elasticity
       end
 
       def search_results
-        @search_results ||= Search::Results.new(response, @search_definition, @mapper)
+        @search_results ||= Search::Results.new(response, @search_definition.body, @mapper)
       end
 
       private
@@ -172,7 +172,7 @@ module Elasticity
             response = @client.scroll(scroll_id: response["_scroll_id"], scroll: @scroll)
             break if response["hits"]["hits"].empty?
 
-            y << Search::Results.new(response, @search_definition, @mapper)
+            y << Search::Results.new(response, @search_definition.body, @mapper)
           end
         end
       end
@@ -286,9 +286,9 @@ module Elasticity
 
       DEFAULT_SIZE = 10
 
-      def initialize(response, search_definition, mapper = nil)
+      def initialize(response, body, mapper = nil)
         @response = response
-        @search_definition = search_definition
+        @body = body
         @documents = if mapper.nil?
           @response["hits"]["hits"]
         else
@@ -310,7 +310,7 @@ module Elasticity
 
       # for pagination
       def per_page
-        @search_definition.body[:size] || DEFAULT_SIZE
+        @body[:size] || DEFAULT_SIZE
       end
 
       # for pagination
@@ -320,8 +320,8 @@ module Elasticity
 
       # for pagination
       def current_page
-        return 1 if @search_definition.body[:from].nil?
-        @search_definition.body[:from] / per_page + 1
+        return 1 if @body[:from].nil?
+        @body[:from] / per_page + 1
       end
     end
   end

--- a/lib/elasticity/search.rb
+++ b/lib/elasticity/search.rb
@@ -187,7 +187,6 @@ module Elasticity
 
     class ActiveRecordProxy
       def self.from_hits(relation, search_definition, response)
-        relation
         ids = response["hits"]["hits"].map { |hit| hit["_id"] }
 
         if ids.any?
@@ -205,6 +204,7 @@ module Elasticity
         def initialize(relation, search_definition, response)
           @relation = relation
           @search_definition = search_definition
+          @response = response
         end
 
         def method_missing(name, *args, &block)
@@ -218,7 +218,7 @@ module Elasticity
         end
 
         def total
-          response["hits"]["total"]
+          @response["hits"]["total"]
         end
 
         # for pagination

--- a/spec/units/multi_search_spec.rb
+++ b/spec/units/multi_search_spec.rb
@@ -41,7 +41,6 @@ RSpec.describe Elasticity::MultiSearch do
 
     expect(Array(subject[:first])). to eq [klass.new(_id: 1, name: "foo"), klass.new(_id: 2, name: "bar")]
     expect(Array(subject[:second])). to eq [klass.new(_id: 3, name: "baz")]
-    expect(subject.total).to eq(3)
     expect(subject.each).to be_a Enumerable
   end
 end

--- a/spec/units/multi_search_spec.rb
+++ b/spec/units/multi_search_spec.rb
@@ -41,5 +41,7 @@ RSpec.describe Elasticity::MultiSearch do
 
     expect(Array(subject[:first])). to eq [klass.new(_id: 1, name: "foo"), klass.new(_id: 2, name: "bar")]
     expect(Array(subject[:second])). to eq [klass.new(_id: 3, name: "baz")]
+    expect(subject.total).to eq(3)
+    expect(subject.each).to be_a Enumerable
   end
 end

--- a/spec/units/multi_search_spec.rb
+++ b/spec/units/multi_search_spec.rb
@@ -31,15 +31,18 @@ RSpec.describe Elasticity::MultiSearch do
   end
 
   it "performs multi search" do
-    subject.add(:first, Elasticity::Search::Facade.new(client, Elasticity::Search::Definition.new("index_first", "document_first", { search: :first })), documents: klass)
+    subject.add(:first, Elasticity::Search::Facade.new(client, Elasticity::Search::Definition.new("index_first", "document_first", { search: :first, size: 2 })), documents: klass)
     subject.add(:second, Elasticity::Search::Facade.new(client, Elasticity::Search::Definition.new("index_second", "document_second", { search: :second })), documents: klass)
 
     expect(Elasticity.config.client).to receive(:msearch).with(body: [
-      { index: "index_first", type: "document_first", search: { search: :first } },
+      { index: "index_first", type: "document_first", search: { search: :first, size: 2 } },
       { index: "index_second", type: "document_second", search: { search: :second } },
     ]).and_return(response)
 
-    expect(Array(subject[:first])). to eq [klass.new(_id: 1, name: "foo"), klass.new(_id: 2, name: "bar")]
-    expect(Array(subject[:second])). to eq [klass.new(_id: 3, name: "baz")]
+    expect(Array(subject[:first])).to eq [klass.new(_id: 1, name: "foo"), klass.new(_id: 2, name: "bar")]
+    expect(Array(subject[:second])).to eq [klass.new(_id: 3, name: "baz")]
+    expect(subject[:first].total).to eq 2
+    expect(subject[:first].total_pages).to eq 1
+    expect(subject[:first].current_page).to eq 1
   end
 end

--- a/spec/units/multi_search_spec.rb
+++ b/spec/units/multi_search_spec.rb
@@ -41,6 +41,5 @@ RSpec.describe Elasticity::MultiSearch do
 
     expect(Array(subject[:first])). to eq [klass.new(_id: 1, name: "foo"), klass.new(_id: 2, name: "bar")]
     expect(Array(subject[:second])). to eq [klass.new(_id: 3, name: "baz")]
-    expect(subject.each).to be_a Enumerable
   end
 end

--- a/spec/units/search_spec.rb
+++ b/spec/units/search_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Search" do
   let(:client)         { double(:client) }
   let(:index_name)     { "index_name" }
   let(:document_type)  { "document" }
-  let(:body)           { {} }
+  let(:body)           { { } }
 
   let :full_response do
     { "hits" => { "total" => 2, "hits" => [
@@ -132,6 +132,7 @@ RSpec.describe "Search" do
         klass: double(:klass, primary_key: "id"),
         to_sql: "SELECT * FROM table_name WHERE id IN (1)"
       )
+
       allow(relation.connection).to receive(:quote_column_name) { |name| name }
       allow(relation.connection).to receive(:quote) { |name| name }
 
@@ -167,7 +168,7 @@ RSpec.describe "Search" do
           index: index_name,
           type: document_type,
           body: { size: 14, from: 25, filter: {} }
-        ).and_return({ "hits" => { "total" => 112 } })
+        ).and_return({ "hits" => { "total" => 112, "hits" => [] } })
       docs = subject.documents(mapper)
 
       expect(docs.per_page).to eq(14)

--- a/spec/units/search_spec.rb
+++ b/spec/units/search_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Search" do
   let(:client)         { double(:client) }
   let(:index_name)     { "index_name" }
   let(:document_type)  { "document" }
-  let(:body)           { { } }
+  let(:body)           { {} }
 
   let :full_response do
     { "hits" => { "total" => 2, "hits" => [


### PR DESCRIPTION
This provides a total method on the multi search response object and makes it possible to work off of the returned object rather than having to build an array of arrays directly.  Shouldn't break backwards compatibility as consumers can still build a nested array via the `[]` if they wish to.