### PR TITLE
bulk_update allows document's attributes be updated individually

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,10 @@
+v0.5.1
+  - Add ability to reindex individual attributes of a document using the
+  bulk_update API.
 v0.5.0
 	- Refactor of multisearch and search facade
 	- add Search::Results proxy object so pagination and meta data methods can
-	be standardize across all responses  
+	be standardize across all responses
   - Searches no longer return a simple array, they now return the
   Search::Results object which proxies array and is enumerable.
 v0.4.5

--- a/README.md
+++ b/README.md
@@ -129,6 +129,19 @@ users = [
 Search::User.bulk_index(users)
 ```
 
+### Individual Attribute Indexing
+
+If you you'd like to update a single attribute of the document instead of updating the entire document, you can use the `bulk_update` api.
+
+```ruby
+document = [
+  { _id: 1, attr_name: "attr_name", attr_vale: "attr_value" },
+  { _id: 2, attr_name: "attr_name", attr_vale: "attr_value" }
+]
+
+Search::User.bulk_update(documents)
+```
+
 
 ### Searching
 
@@ -244,7 +257,7 @@ This class on itself can't be queried or manipulated directly. Trying to call th
 users = Search::User.segment("doximity.com")
 users.create_index
 
-# users is a dynamically defined class that inherits from the Search::User class, 
+# users is a dynamically defined class that inherits from the Search::User class,
 # therefore having all the necessary methods defined just properly.
 users           # => Search::User{"doximity.com"}
 users.class     # => Class

--- a/lib/elasticity/bulk.rb
+++ b/lib/elasticity/bulk.rb
@@ -9,6 +9,10 @@ module Elasticity
       @operations << { index: { _index: index_name, _type: type, _id: id, data: attributes }}
     end
 
+    def update(index_name, type, id, attributes)
+      @operations << { update: { _index: index_name, _type: type, _id: id, data: attributes }}
+    end
+
     def delete(index_name, type, id)
       @operations << { delete: { _index: index_name, _type: type, _id: id }}
     end
@@ -27,6 +31,10 @@ module Elasticity
         super(@index_name, type, id, attributes)
       end
 
+      def update(type, id, attributes)
+        super(@index_name, type, id, attributes)
+      end
+
       def delete(type, id)
         super(@index_name, type, id)
       end
@@ -40,6 +48,10 @@ module Elasticity
       end
 
       def index(type, id, attributes)
+        super(@update_alias, type, id, attributes)
+      end
+
+      def update(type, id, attributes)
         super(@update_alias, type, id, attributes)
       end
 

--- a/lib/elasticity/index_mapper.rb
+++ b/lib/elasticity/index_mapper.rb
@@ -118,7 +118,7 @@ module Elasticity
           b.update(
             document_type,
             doc[:_id],
-            { doc: { doc[:attr_name] => doc[:attr_vale] } }
+            { doc: { doc[:attr_name] => doc[:attr_value] } }
           )
         end
       end

--- a/lib/elasticity/index_mapper.rb
+++ b/lib/elasticity/index_mapper.rb
@@ -17,6 +17,7 @@ module Elasticity
         :delete,
         :delete_by_search,
         :bulk_index,
+        :bulk_update,
         :bulk_delete,
         :map_hit,
         to: to
@@ -106,6 +107,19 @@ module Elasticity
       @strategy.bulk do |b|
         documents.each do |doc|
           b.index(document_type, doc._id, doc.to_document)
+        end
+      end
+    end
+
+    # Bulk update the specicied attribute of the provided documents
+    def bulk_update(documents)
+      @strategy.bulk do |b|
+        documents.each do |doc|
+          b.update(
+            document_type,
+            doc[:_id],
+            { doc: { doc[:attr_name] => doc[:attr_vale] } }
+          )
         end
       end
     end

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end


### PR DESCRIPTION
Implement bulk_update which allows document's attributes be updated individually instead of having to update the entire document.