### PR TITLE
Access the sort array of each result.

### DIFF
--- a/lib/elasticity/base_document.rb
+++ b/lib/elasticity/base_document.rb
@@ -12,7 +12,7 @@ module Elasticity
     end
 
     # Define common attributes for all documents
-    attr_accessor :_id, :highlighted, :_score
+    attr_accessor :_id, :highlighted, :_score, :sort
 
     def attributes=(attributes)
       attributes.each do |attr, value|

--- a/lib/elasticity/index_mapper.rb
+++ b/lib/elasticity/index_mapper.rb
@@ -138,6 +138,7 @@ module Elasticity
     def map_hit(hit)
       attrs = { _id: hit["_id"] }
       attrs.merge!(_score: hit["_score"])
+      attrs.merge!(sort: hit["sort"])
       attrs.merge!(hit["_source"]) if hit["_source"]
 
       if hit["highlight"]

--- a/spec/functional/persistence_spec.rb
+++ b/spec/functional/persistence_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe "Persistence", elasticsearch: true do
     end
 
     it "successfully index, update, search, count and delete" do
-      john = subject.new(name: "John", birthdate: "1985-10-31")
-      mari = subject.new(name: "Mari", birthdate: "1986-09-24")
+      john = subject.new(name: "John", birthdate: "1985-10-31", sort: ['john'])
+      mari = subject.new(name: "Mari", birthdate: "1986-09-24", sort: ['mari'])
 
       john.update
       mari.update
@@ -194,8 +194,8 @@ RSpec.describe "Persistence", elasticsearch: true do
     end
 
     it "remaps to a different index transparently" do
-      john = subject.new(id: 1, name: "John", birthdate: "1985-10-31")
-      mari = subject.new(id: 2, name: "Mari", birthdate: "1986-09-24")
+      john = subject.new(id: 1, name: "John", birthdate: "1985-10-31", sort: ['john'])
+      mari = subject.new(id: 2, name: "Mari", birthdate: "1986-09-24", sort: ['mari'])
 
       john.update
       mari.update


### PR DESCRIPTION
The use case is a search that sorts results by distance using the function geo_distance, and I would like to present the calculated distance. Elasticsearch makes the calculated distance available in the sort property.

Example of `geo_distance` query and the returned `sort`. 
http://www.elasticsearchtutorial.com/spatial-search-tutorial.html