### PR TITLE
multi search failure info

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v0.6.2
+	- update multi search `[]` method to raise an exception with key name to
+	make it easier to debug failed queries within a multi search hash.
 v0.6.0
 	- Change documents to be able to define indexes with multiple doc types.  A
 	Document class can define subclasses which are of different doc_types and

--- a/lib/elasticity/multi_search.rb
+++ b/lib/elasticity/multi_search.rb
@@ -25,6 +25,8 @@ module Elasticity
 
     def [](name)
       results_collection[name]
+    rescue NoMethodError => e
+      raise "#{e.inspect} with key #{name}"
     end
 
     private

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = "0.6.1"
+  VERSION = "0.6.2"
 end


### PR DESCRIPTION
This will provide the key that the multi search query failed on so you know which indexes need to be rebuilt or which query needs to be modified.