### PR TITLE
expand search options

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v0.6.5
+	- update search and multi search interfaces to allow passing of general
+	search definition arguments found in https://github.com/elastic/elasticsearch-ruby/blob/bdf5e145e5acc21726dddcd34492debbbddde568/elasticsearch-api/lib/elasticsearch/api/actions/search.rb#L125-L162
 v0.6.4
 	- update suggestions to pull from the proper key
 v0.6.3

--- a/lib/elasticity/multi_search.rb
+++ b/lib/elasticity/multi_search.rb
@@ -1,9 +1,10 @@
 module Elasticity
   class MultiSearch
 
-    def initialize
+    def initialize(msearch_args={})
       @searches = {}
       @mappers  = {}
+      @msearch_args = msearch_args
       yield self if block_given?
     end
 
@@ -25,8 +26,6 @@ module Elasticity
 
     def [](name)
       results_collection[name]
-    rescue NoMethodError => e
-      raise "#{e.inspect} with key #{name}"
     end
 
     private
@@ -41,7 +40,8 @@ module Elasticity
       end
 
       response = ActiveSupport::Notifications.instrument("multi_search.elasticity", args: { body: bodies }) do
-        Elasticity.config.client.msearch(body: bodies.map(&:dup))
+        args = { body: bodies.map(&:dup) }.reverse_merge(@msearch_args)
+        Elasticity.config.client.msearch(args)
       end
       results = {}
 

--- a/lib/elasticity/multi_search.rb
+++ b/lib/elasticity/multi_search.rb
@@ -1,7 +1,7 @@
 module Elasticity
   class MultiSearch
 
-    def initialize(msearch_args={})
+    def initialize(msearch_args = {})
       @searches = {}
       @mappers  = {}
       @msearch_args = msearch_args

--- a/lib/elasticity/search.rb
+++ b/lib/elasticity/search.rb
@@ -8,12 +8,13 @@ module Elasticity
     # Elasticity::Search::Definition is a struct that encapsulates all the data specific to one
     # ElasticSearch search.
     class Definition
-      attr_accessor :index_name, :document_types, :body
+      attr_accessor :index_name, :document_types, :body, :search_args
 
-      def initialize(index_name, document_types, body)
-        @index_name    = index_name
+      def initialize(index_name, document_types, body, search_args={})
+        @index_name     = index_name
         @document_types = document_types
-        @body          = body.deep_symbolize_keys!
+        @body           = body.deep_symbolize_keys!
+        @search_args           = search_args.symbolize_keys!
       end
 
       def update(body_changes)
@@ -21,18 +22,18 @@ module Elasticity
       end
 
       def to_count_args
-        { index: @index_name, type: @document_types}.tap do |args|
+        { index: @index_name, type: @document_types}.reverse_merge(search_args).tap do |args|
           body = @body.slice(:query)
           args[:body] = body if body.present?
         end
       end
 
       def to_search_args
-        { index: @index_name, type: @document_types, body: @body }
+        { index: @index_name, type: @document_types, body: @body }.reverse_merge(search_args)
       end
 
       def to_msearch_args
-        { index: @index_name, type: @document_types, search: @body }
+        { index: @index_name, type: @document_types, search: @body }.reverse_merge(search_args)
       end
     end
 

--- a/lib/elasticity/search.rb
+++ b/lib/elasticity/search.rb
@@ -51,14 +51,14 @@ module Elasticity
 
       # Performs the search using the default search type and returning an iterator that will yield
       # hash representations of the documents.
-      def document_hashes(search_args={})
+      def document_hashes(search_args = {})
         return @document_hashes if defined?(@document_hashes)
         @document_hashes = LazySearch.new(@client, @search_definition, search_args)
       end
 
       # Performs the search using the default search type and returning an iterator that will yield
       # each document, converted using the provided mapper
-      def documents(mapper, search_args={})
+      def documents(mapper, search_args = {})
         return @documents if defined?(@documents)
         @documents = LazySearch.new(@client, @search_definition, search_args) do |hit|
           mapper.(hit)
@@ -264,7 +264,7 @@ module Elasticity
 
       delegate :search_definition, :active_records, to: :@search
 
-      def documents(search_args={})
+      def documents(search_args = {})
         @search.documents(@document_klass, search_args)
       end
 

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = "0.6.4"
+  VERSION = "0.6.5"
 end

--- a/spec/units/search_spec.rb
+++ b/spec/units/search_spec.rb
@@ -179,6 +179,22 @@ RSpec.describe "Search" do
       expect(docs.next_page).to eq(3)
       expect(docs.previous_page).to eq(1)
     end
+
+    it "merges in additional arguments for search" do
+      results = double(:results, :[] => { "hits" => [] })
+      subject = Elasticity::Search::Facade.new(
+        client,
+        Elasticity::Search::Definition.new(index_name, document_type, {})
+      )
+
+      expect(client).to receive(:search).with(
+        index: index_name,
+        type: document_type,
+        body: {},
+        search_type: :dfs_query_and_fetch
+      ).and_return(results)
+      subject.documents(mapper, search_type: :dfs_query_and_fetch).search_results
+    end
   end
 
   describe Elasticity::Search::DocumentProxy do
@@ -201,5 +217,13 @@ RSpec.describe "Search" do
       expect(search).to receive(:active_records).with(rel).and_return(records)
       expect(subject.active_records(rel)).to be records
     end
+
+    it "accepts additional arguments for a search" do
+      results = double(:results)
+
+      expect(search).to receive(:documents).with(mapper, search_type: :dfs_query_then_fetch).and_return(results)
+      expect(subject.documents(search_type: :dfs_query_then_fetch)).to eq(results)
+    end
+
   end
 end


### PR DESCRIPTION
you can now pass any of the options found in
https://github.com/elastic/elasticsearch-ruby/blob/bdf5e145e5acc21726dddcd34492debbbddde568/elasticsearch-api/lib/elasticsearch/api/actions/search.rb#L125-L162
to a search definition.