### PR TITLE
travis: support ruby 2.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - 2.1.4
   - 2.2.2
   - 2.2.3
+  - 2.3.1
 services:
   - elasticsearch
 before_script:

--- a/lib/elasticity/search.rb
+++ b/lib/elasticity/search.rb
@@ -84,7 +84,7 @@ module Elasticity
     class LazySearch
       include Enumerable
 
-      delegate :each, :size, :length, :[], :+, :-, :&, :|, :total, :per_page,
+      delegate :each, :to_ary, :size, :length, :[], :+, :-, :&, :|, :total, :per_page,
         :total_pages, :current_page, :next_page, :previous_page, :aggregations, to: :search_results
 
       attr_accessor :search_definition


### PR DESCRIPTION
Somewhere in the upgrade to Ruby the behavior for LazySearch was changed
so that it no longer had a to_ary method inherited/included. Maybe
Enumerable provided this? This will delegate it to search_results.