### PR TITLE
update scan api to work with modern versions of elasticsearch ruby

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+v0.8.2
+	- fix scan api to work with more recent versions of elasticsearch ruby.
 v0.8.1
 	- loosen support for elasticsearch-ruby versions to support more versions of
 	elasticsearch

--- a/lib/elasticity/search.rb
+++ b/lib/elasticity/search.rb
@@ -166,7 +166,7 @@ module Elasticity
           response = search
 
           loop do
-            response = @client.scroll(scroll_id: response["_scroll_id"], scroll: @scroll)
+            response = @client.scroll(scroll_id: response["_scroll_id"], scroll: @scroll, body: { scroll_id: response["_scroll_id"] })
             break if response["hits"]["hits"].empty?
 
             y << Search::Results.new(response, @search_definition.body, @mapper)

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = "0.8.1"
+  VERSION = "0.8.2"
 end

--- a/spec/units/search_spec.rb
+++ b/spec/units/search_spec.rb
@@ -109,8 +109,8 @@ RSpec.describe "Search" do
 
     it "searches using scan&scroll" do
       expect(client).to receive(:search).with(index: index_name, type: document_type, body: body, search_type: :query_then_fetch, size: 100, scroll: "1m").and_return(scan_response)
-      expect(client).to receive(:scroll).with(scroll_id: "abc123", scroll: "1m").and_return(scroll_response)
-      expect(client).to receive(:scroll).with(scroll_id: "abc456", scroll: "1m").and_return(empty_response)
+      expect(client).to receive(:scroll).with(scroll_id: "abc123", scroll: "1m", body: { scroll_id: "abc123" }).and_return(scroll_response)
+      expect(client).to receive(:scroll).with(scroll_id: "abc456", scroll: "1m", body: { scroll_id: "abc456" }).and_return(empty_response)
 
       docs = subject.scan_documents(mapper)
       expected = [klass.new(_id: 1, name: "foo"), klass.new(_id: 2, name: "bar")]


### PR DESCRIPTION
elasticsearch ruby requires a body passed as part of the scan api so now
we pass one that complies with what the client requests.

https://github.com/elastic/elasticsearch-ruby/blob/5.x/elasticsearch-api/lib/elasticsearch/api/actions/scroll.rb