### PR TITLE
WIP - Raise error on ES error response 

### DIFF
--- a/lib/elasticity/multi_search.rb
+++ b/lib/elasticity/multi_search.rb
@@ -53,7 +53,6 @@ module Elasticity
       @searches.keys.each_with_index do |name, idx|
         resp = response["responses"][idx]
         search = @searches[name]
-        raise "Error: #{resp}" if resp["error"]
         results[name] = case
         when search[:documents]
           Search::Results.new(resp, search[:search_definition].body, search[:documents].method(:map_hit))

--- a/lib/elasticity/search.rb
+++ b/lib/elasticity/search.rb
@@ -1,5 +1,7 @@
 module Elasticity
   module Search
+    class ElasticSearchError < StandardError; end
+
     def self.build(client, index_name, document_types, body)
       search_def = Search::Definition.new(index_name, document_types, body)
       Search::Facade.new(client, search_def)
@@ -285,6 +287,8 @@ module Elasticity
       DEFAULT_SIZE = 10
 
       def initialize(response, body, mapper = nil)
+        raise ElasticSearchError, response.to_json if response["error"]
+
         @response = response
         @body = body
         @documents = if mapper.nil?


### PR DESCRIPTION
The idea is to bubble up any error retrieved in an ES response. Right now `Elasticity` is hiding any ES error due to a parsing issue.

This is the `backtrace` I'm getting:
```
".../gems/es-elasticity-0.8.2/lib/elasticity/search.rb:293:in `initialize'",
".../gems/es-elasticity-0.8.2/lib/elasticity/multi_search.rb:54:in `new'",
".../gems/es-elasticity-0.8.2/lib/elasticity/multi_search.rb:54:in `block in fetch'",
".../gems/es-elasticity-0.8.2/lib/elasticity/multi_search.rb:48:in `each'",
".../gems/es-elasticity-0.8.2/lib/elasticity/multi_search.rb:48:in `each_with_index'",
".../gems/es-elasticity-0.8.2/lib/elasticity/multi_search.rb:48:in `fetch'",
".../gems/es-elasticity-0.8.2/lib/elasticity/multi_search.rb:34:in `results_collection'",
".../gems/es-elasticity-0.8.2/lib/elasticity/multi_search.rb:28:in `[]'",
```

when the ES response contain errors like
```json
  {
    "error":{
      "root_cause":[{"type":"too_many_clauses","reason":"too_many_clauses: maxClauseCount is set to 1024"}],
      "type":"search_phase_execution_exception",
      "reason":"all shards failed",
      "phase":"dfs",
      "grouped":true,
      "failed_shards":[ ... ],
      "caused_by":{ ... }
    },
    "status":400
   }
```
