### PR TITLE
fix bug in remap to use scan api properly

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+v0.8.3
+	- fix remap method to use the scan api properly.
 v0.8.2
 	- fix scan api to work with more recent versions of elasticsearch ruby.
 v0.8.1

--- a/lib/elasticity/strategies/alias_index.rb
+++ b/lib/elasticity/strategies/alias_index.rb
@@ -83,7 +83,7 @@ module Elasticity
             end
 
             @client.bulk(body: ops) unless ops.empty?
-            cursor = @client.scroll(scroll_id: cursor['_scroll_id'], scroll: '1m')
+            cursor = @client.scroll(scroll_id: cursor['_scroll_id'], scroll: '1m', body: { scroll_id: cursor["_scroll_id"] })
           end
 
           # Update aliases to only point to the new index.

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = "0.8.2"
+  VERSION = "0.8.3"
 end


### PR DESCRIPTION
Because of a bug in elasticsearch ruby gem the scan id must be passed
directly in the body.
https://github.com/elastic/elasticsearch-ruby/issues/423