### PR TITLE
[WIP] raise error when keys in document are not present in mapping

### DIFF
--- a/lib/elasticity/base_document.rb
+++ b/lib/elasticity/base_document.rb
@@ -39,6 +39,7 @@ module Elasticity
 
     # Update this object on the index, creating or updating the document.
     def update
+      raise ArgumentError, "document contains keys not present in the mapping" unless document_respects_mapping?
       self._id, @created = self.class.index_document(_id, to_document)
     end
 
@@ -51,6 +52,10 @@ module Elasticity
     end
 
     private
+
+    def document_respects_mapping?
+      (to_document.keys - config.mapping[:properties].keys).empty?
+    end
 
     def self.index_config_defaults
       {

--- a/spec/units/document_spec.rb
+++ b/spec/units/document_spec.rb
@@ -60,4 +60,30 @@ RSpec.describe Elasticity::Document do
       expect(subject.config.definition[:settings][:number_of_shards]).to eq 2
     end
   end
+
+  context "keys in document do not exist in mapping" do
+
+    it "raises an error on update" do
+      broke_klass = Class.new(described_class) do
+        def self.name
+          "SomeClass"
+        end
+
+        configure do |c|
+          c.index_base_name = "class_names"
+          c.document_type   = "class_name"
+          c.mapping         = mappings
+          c.settings = { number_of_shards: 2 }
+        end
+
+        attr_accessor :name, :items
+
+        def to_document
+          { not_a_thing: true }
+        end
+      end
+
+      expect { broke_klass.new(_id: 1, name: "Foo", items: [{ name: "Item1" }]).update }.to raise_error(ArgumentError)
+    end
+  end
 end


### PR DESCRIPTION
Currently it is possible for fields in the document (from `to_document`) to be saved to the index, regardless of whether they're defined in the mapping. At a minimum there should be a check/warning when there is a mismatch between the two. This is a first stab to isolate the problem.