### PR TITLE
update remap method to remove undefined mapping properties

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v0.10.0
+	- update remap to removing fields from the mapping that are not explicitly
+	defined.
 v0.9.1
 	- fix search enumerator, missing first result set
 v0.8.3

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = "0.9.1"
+  VERSION = "0.10.0"
 end


### PR DESCRIPTION
If a field is not explicitly defined in an index's mapping we should not
persist it via the documents we copy over as part of remap.  This allows
for a way to get around the limitation in lucene where you can't delete
fields from index mappings without recreating the index from scratch.