### PR TITLE
155727289 do not raise on msearch error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in elasticity.gemspec
 gemspec
 
-gem "elasticsearch", "5.0.3"
+gem "elasticsearch", "5.0.4"

--- a/lib/elasticity/index_mapper.rb
+++ b/lib/elasticity/index_mapper.rb
@@ -83,7 +83,9 @@ module Elasticity
     # structure Elasticsearch expects.
     # Returns a DocumentSearch object.
     def search(body)
-      search_obj = Search.build(@index_config.client, @strategy.search_index, document_types, body)
+      ignore_unavailable = body.fetch("ignore_unavailable") { false }
+      body = body.except("ignore_unavailable")
+      search_obj = Search.build(@index_config.client, @strategy.search_index, document_types, body, ignore_unavailable)
       Search::DocumentProxy.new(search_obj, self.method(:map_hit))
     end
 

--- a/lib/elasticity/multi_search.rb
+++ b/lib/elasticity/multi_search.rb
@@ -4,6 +4,7 @@ module Elasticity
       @results  = {}
       @searches = {}
       @mappers  = {}
+      @skip_raise_on_errors = msearch_args.delete(:skip_raise_on_errors)
       @msearch_args = msearch_args
       yield self if block_given?
     end
@@ -35,7 +36,7 @@ module Elasticity
       return if search.nil?
 
       query_response = response_for(@searches.keys.index(name))
-      MultiSearchResponseParser.parse(query_response, search)
+      MultiSearchResponseParser.parse(query_response, search, skip_raise_on_errors: @skip_raise_on_errors)
     end
 
     def response_for(index)

--- a/lib/elasticity/search.rb
+++ b/lib/elasticity/search.rb
@@ -1,7 +1,7 @@
 module Elasticity
   module Search
-    def self.build(client, index_name, document_types, body)
-      search_def = Search::Definition.new(index_name, document_types, body)
+    def self.build(client, index_name, document_types, body, ignore_unavailable = false)
+      search_def = Search::Definition.new(index_name, document_types, body, ignore_unavailable)
       Search::Facade.new(client, search_def)
     end
 
@@ -10,10 +10,11 @@ module Elasticity
     class Definition
       attr_accessor :index_name, :document_types, :body
 
-      def initialize(index_name, document_types, body)
+      def initialize(index_name, document_types, body, ignore_unavailable = false)
         @index_name     = index_name
         @document_types = document_types
         @body           = body.deep_symbolize_keys!
+        @ignore_unavailable = ignore_unavailable
       end
 
       def update(body_changes)
@@ -28,7 +29,13 @@ module Elasticity
       end
 
       def to_search_args
-        { index: @index_name, type: @document_types, body: @body }
+        args = {
+          index: @index_name,
+          type: @document_types,
+          body: @body
+        }
+        args[:ignore_unavailable] = @ignore_unavailable if @ignore_unavailable
+        args
       end
 
       def to_msearch_args

--- a/lib/elasticity/search.rb
+++ b/lib/elasticity/search.rb
@@ -335,6 +335,14 @@ module Elasticity
       def previous_page
         current_page > 1 ? (current_page - 1) : nil
       end
+
+      def error
+        @response["error"]
+      end
+
+      def exception
+        @response["exception"]
+      end
     end
   end
 end

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = "0.11.0.pre-dkb"
+  VERSION = "0.11.1.pre.dkb"
 end

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = "0.10.0"
+  VERSION = "0.11.0.pre-dkb"
 end

--- a/spec/units/index_mapper_spec.rb
+++ b/spec/units/index_mapper_spec.rb
@@ -1,4 +1,49 @@
 require "elasticity/index_mapper"
 
-RSpec.describe Elasticity::IndexMapper do
+RSpec.describe Elasticity::IndexMapper, elasticsearch: true do
+  describe "single index strategy" do
+    subject do
+      Class.new(Elasticity::Document) do
+        def self.name
+          'SomeClass'
+        end
+
+        configure do |c|
+          c.index_base_name = "users"
+          c.document_type   = "user"
+          c.strategy        = Elasticity::Strategies::SingleIndex
+
+          c.mapping = {
+            "properties" => {
+              name: { type: "string", index: "not_analyzed" },
+              birthdate: { type: "date" },
+            },
+          }
+        end
+
+        attr_accessor :name, :birthdate
+
+        def to_document
+          { name: name, birthdate: birthdate }
+        end
+      end
+    end
+
+    before do
+      subject.recreate_index
+      @elastic_search_client.cluster.health wait_for_status: 'yellow'
+    end
+
+    it "will not raise an exception on missing index if arg is passed in body" do
+      subject.delete_index
+      results = subject.search({"ignore_unavailable" => true})
+      expect(results.total).to eq 0
+    end
+
+    it "will raise an exception on missing index if arg is not passed in body" do
+      subject.delete_index
+      results = subject.search({})
+      expect { results.total }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
+    end
+  end
 end

--- a/spec/units/multi_search_response_parser_spec.rb
+++ b/spec/units/multi_search_response_parser_spec.rb
@@ -70,6 +70,22 @@ RSpec.describe Elasticity::MultiSearchResponseParser do
                       response.to_json
         )
       end
+
+      context "passing :skip_raise_on_errors as true" do
+        it "does not raise" do
+          expect { described_class.parse(response, search, skip_raise_on_errors: true) }.not_to(raise_error)
+        end
+
+        it "returns a response containing the error" do
+          expected_exception =
+            Elasticsearch::Transport::Transport::Errors::BadRequest.new(response.to_json)
+          parsed = described_class.parse(response, search, skip_raise_on_errors: true)
+          expect(parsed.error).to eq(response["error"])
+          expect(parsed.total).to eq(0)
+          expect(parsed.aggregations).to eq({})
+          expect(parsed.exception).to eq(expected_exception)
+        end
+      end
     end
 
     context "for a 500 error response" do
@@ -93,6 +109,22 @@ RSpec.describe Elasticity::MultiSearchResponseParser do
                       response.to_json
         )
       end
+
+      context "passing :skip_raise_on_errors as true" do
+        it "does not raise" do
+          expect { described_class.parse(response, search, skip_raise_on_errors: true) }.not_to(raise_error)
+        end
+
+        it "returns a response containing the error" do
+          expected_exception =
+            Elasticsearch::Transport::Transport::Errors::InternalServerError.new(response.to_json)
+          parsed = described_class.parse(response, search, skip_raise_on_errors: true)
+          expect(parsed.error).to eq(response["error"])
+          expect(parsed.total).to eq(0)
+          expect(parsed.aggregations).to eq({})
+          expect(parsed.exception).to eq(expected_exception)
+        end
+      end
     end
 
     context "for an unknown error response" do
@@ -115,6 +147,22 @@ RSpec.describe Elasticity::MultiSearchResponseParser do
           raise_error Elasticity::MultiSearchResponseParser::UnknownError,
                       response.to_json
         )
+      end
+
+      context "passing :skip_raise_on_errors as true" do
+        it "does not raise" do
+          expect { described_class.parse(response, search, skip_raise_on_errors: true) }.not_to(raise_error)
+        end
+
+        it "returns a response containing the error" do
+          expected_exception =
+            Elasticity::MultiSearchResponseParser::UnknownError.new(response.to_json)
+          parsed = described_class.parse(response, search, skip_raise_on_errors: true)
+          expect(parsed.error).to eq(response["error"])
+          expect(parsed.total).to eq(0)
+          expect(parsed.aggregations).to eq({})
+          expect(parsed.exception).to eq(expected_exception)
+        end
       end
     end
   end

--- a/spec/units/multi_search_spec.rb
+++ b/spec/units/multi_search_spec.rb
@@ -154,5 +154,15 @@ RSpec.describe Elasticity::MultiSearch do
       expect(Array(subject[:first])).to eq [klass.new(_id: 1, name: "foo"), klass.new(_id: 2, name: "bar")]
       expect { subject[:third] }.to raise_error Elasticsearch::Transport::Transport::Errors::BadRequest, error.to_json
     end
+
+    it "skips raising an error while trying to access the query result if so directed" do
+      subject = Elasticity::MultiSearch.new(skip_raise_on_errors: true)
+      subject.add(:first, Elasticity::Search::Facade.new(client, Elasticity::Search::Definition.new("index_first", "document_first", { search: :first, size: 2 })), documents: klass)
+      subject.add(:second, Elasticity::Search::Facade.new(client, Elasticity::Search::Definition.new("index_second", "document_second", { search: :second })), documents: klass)
+      subject.add(:third, Elasticity::Search::Facade.new(client, Elasticity::Search::Definition.new("index_third", "document_third", { search: :third })), documents: klass)
+
+      expect(Array(subject[:first])).to eq [klass.new(_id: 1, name: "foo"), klass.new(_id: 2, name: "bar")]
+      expect(subject[:third].error).to eq(error["error"])
+    end
   end
 end

--- a/spec/units/search_spec.rb
+++ b/spec/units/search_spec.rb
@@ -225,6 +225,30 @@ RSpec.describe "Search" do
       expect(search).to receive(:documents).with(mapper, search_type: :dfs_query_then_fetch).and_return(results)
       expect(subject.documents(search_type: :dfs_query_then_fetch)).to eq(results)
     end
+  end
 
+  describe Elasticity::Search::Definition do
+    describe "#to_search_args" do
+      it "does not include :ignore_unavailable by default" do
+        definition = Elasticity::Search::Definition.new("abc", ["a", "b"], { "some" => "body" })
+        expected = {
+          index: "abc",
+          type: ["a", "b"],
+          body: { :some => "body" }
+        }
+        expect(definition.to_search_args).to eq(expected)
+      end
+
+      it "does include :ignore_unavailable when arg is true" do
+        definition = Elasticity::Search::Definition.new("abc", ["a", "b"], { "some" => "body" }, true)
+        expected = {
+          index: "abc",
+          type: ["a", "b"],
+          body: { :some => "body" },
+          ignore_unavailable: true
+        }
+        expect(definition.to_search_args).to eq(expected)
+      end
+    end
   end
 end


### PR DESCRIPTION
PT story: https://www.pivotaltracker.com/story/show/155727289

updated a source gem version because a spec was failing with the older version
https://github.com/elastic/elasticsearch-ruby/blob/master/CHANGELOG.md#504


to more correctly mimic the _msearch API,  allow msearch
to return the errors about an index rather than raising
an exception.  This will let the consumers of the API
display results from the other indexes of the msearch
and handle errors on their side.

Also return a 'null' result set along with the error
and exception info so the consumer can more gracefully
handle the errors without additional case discrimination