### PR TITLE
155727289 do not raise on msearch error

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v0.11.0
+  - flag to skip raising expections when msearch has errors on some indexes
+    (default is to continuing raising to match previous behavior)
 v0.10.0
 	- update remap to removing fields from the mapping that are not explicitly
 	defined.

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in elasticity.gemspec
 gemspec
 
-gem "elasticsearch", "5.0.3"
+gem "elasticsearch", "5.0.4"

--- a/lib/elasticity/multi_search.rb
+++ b/lib/elasticity/multi_search.rb
@@ -4,6 +4,7 @@ module Elasticity
       @results  = {}
       @searches = {}
       @mappers  = {}
+      @skip_raise_on_errors = msearch_args.delete(:skip_raise_on_errors)
       @msearch_args = msearch_args
       yield self if block_given?
     end
@@ -35,7 +36,7 @@ module Elasticity
       return if search.nil?
 
       query_response = response_for(@searches.keys.index(name))
-      MultiSearchResponseParser.parse(query_response, search)
+      MultiSearchResponseParser.parse(query_response, search, skip_raise_on_errors: @skip_raise_on_errors)
     end
 
     def response_for(index)

--- a/lib/elasticity/search.rb
+++ b/lib/elasticity/search.rb
@@ -343,6 +343,10 @@ module Elasticity
       def exception
         @response["exception"]
       end
+
+      def valid?
+        !error.present?
+      end
     end
   end
 end

--- a/lib/elasticity/search.rb
+++ b/lib/elasticity/search.rb
@@ -335,6 +335,14 @@ module Elasticity
       def previous_page
         current_page > 1 ? (current_page - 1) : nil
       end
+
+      def error
+        @response["error"]
+      end
+
+      def exception
+        @response["exception"]
+      end
     end
   end
 end

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = "0.10.0"
+  VERSION = "0.11.0.pre.dkb"
 end

--- a/spec/units/multi_search_response_parser_spec.rb
+++ b/spec/units/multi_search_response_parser_spec.rb
@@ -70,6 +70,22 @@ RSpec.describe Elasticity::MultiSearchResponseParser do
                       response.to_json
         )
       end
+
+      context "passing :skip_raise_on_errors as true" do
+        it "does not raise" do
+          expect { described_class.parse(response, search, skip_raise_on_errors: true) }.not_to(raise_error)
+        end
+
+        it "returns a response containing the error" do
+          expected_exception =
+            Elasticsearch::Transport::Transport::Errors::BadRequest.new(response.to_json)
+          parsed = described_class.parse(response, search, skip_raise_on_errors: true)
+          expect(parsed.error).to eq(response["error"])
+          expect(parsed.total).to eq(0)
+          expect(parsed.aggregations).to eq({})
+          expect(parsed.exception).to eq(expected_exception)
+        end
+      end
     end
 
     context "for a 500 error response" do
@@ -93,6 +109,22 @@ RSpec.describe Elasticity::MultiSearchResponseParser do
                       response.to_json
         )
       end
+
+      context "passing :skip_raise_on_errors as true" do
+        it "does not raise" do
+          expect { described_class.parse(response, search, skip_raise_on_errors: true) }.not_to(raise_error)
+        end
+
+        it "returns a response containing the error" do
+          expected_exception =
+            Elasticsearch::Transport::Transport::Errors::InternalServerError.new(response.to_json)
+          parsed = described_class.parse(response, search, skip_raise_on_errors: true)
+          expect(parsed.error).to eq(response["error"])
+          expect(parsed.total).to eq(0)
+          expect(parsed.aggregations).to eq({})
+          expect(parsed.exception).to eq(expected_exception)
+        end
+      end
     end
 
     context "for an unknown error response" do
@@ -115,6 +147,22 @@ RSpec.describe Elasticity::MultiSearchResponseParser do
           raise_error Elasticity::MultiSearchResponseParser::UnknownError,
                       response.to_json
         )
+      end
+
+      context "passing :skip_raise_on_errors as true" do
+        it "does not raise" do
+          expect { described_class.parse(response, search, skip_raise_on_errors: true) }.not_to(raise_error)
+        end
+
+        it "returns a response containing the error" do
+          expected_exception =
+            Elasticity::MultiSearchResponseParser::UnknownError.new(response.to_json)
+          parsed = described_class.parse(response, search, skip_raise_on_errors: true)
+          expect(parsed.error).to eq(response["error"])
+          expect(parsed.total).to eq(0)
+          expect(parsed.aggregations).to eq({})
+          expect(parsed.exception).to eq(expected_exception)
+        end
       end
     end
   end

--- a/spec/units/multi_search_spec.rb
+++ b/spec/units/multi_search_spec.rb
@@ -154,5 +154,15 @@ RSpec.describe Elasticity::MultiSearch do
       expect(Array(subject[:first])).to eq [klass.new(_id: 1, name: "foo"), klass.new(_id: 2, name: "bar")]
       expect { subject[:third] }.to raise_error Elasticsearch::Transport::Transport::Errors::BadRequest, error.to_json
     end
+
+    it "skips raising an error while trying to access the query result if so directed" do
+      subject = Elasticity::MultiSearch.new(skip_raise_on_errors: true)
+      subject.add(:first, Elasticity::Search::Facade.new(client, Elasticity::Search::Definition.new("index_first", "document_first", { search: :first, size: 2 })), documents: klass)
+      subject.add(:second, Elasticity::Search::Facade.new(client, Elasticity::Search::Definition.new("index_second", "document_second", { search: :second })), documents: klass)
+      subject.add(:third, Elasticity::Search::Facade.new(client, Elasticity::Search::Definition.new("index_third", "document_third", { search: :third })), documents: klass)
+
+      expect(Array(subject[:first])).to eq [klass.new(_id: 1, name: "foo"), klass.new(_id: 2, name: "bar")]
+      expect(subject[:third].error).to eq(error["error"])
+    end
   end
 end

--- a/spec/units/multi_search_spec.rb
+++ b/spec/units/multi_search_spec.rb
@@ -155,14 +155,24 @@ RSpec.describe Elasticity::MultiSearch do
       expect { subject[:third] }.to raise_error Elasticsearch::Transport::Transport::Errors::BadRequest, error.to_json
     end
 
-    it "skips raising an error while trying to access the query result if so directed" do
-      subject = Elasticity::MultiSearch.new(skip_raise_on_errors: true)
-      subject.add(:first, Elasticity::Search::Facade.new(client, Elasticity::Search::Definition.new("index_first", "document_first", { search: :first, size: 2 })), documents: klass)
-      subject.add(:second, Elasticity::Search::Facade.new(client, Elasticity::Search::Definition.new("index_second", "document_second", { search: :second })), documents: klass)
-      subject.add(:third, Elasticity::Search::Facade.new(client, Elasticity::Search::Definition.new("index_third", "document_third", { search: :third })), documents: klass)
+    context "skipping raising of error" do
+      before do
+        @subject = Elasticity::MultiSearch.new(skip_raise_on_errors: true)
+        @subject.add(:first, Elasticity::Search::Facade.new(client, Elasticity::Search::Definition.new("index_first", "document_first", { search: :first, size: 2 })), documents: klass)
+        @subject.add(:second, Elasticity::Search::Facade.new(client, Elasticity::Search::Definition.new("index_second", "document_second", { search: :second })), documents: klass)
+        @subject.add(:third, Elasticity::Search::Facade.new(client, Elasticity::Search::Definition.new("index_third", "document_third", { search: :third })), documents: klass)
+      end
 
-      expect(Array(subject[:first])).to eq [klass.new(_id: 1, name: "foo"), klass.new(_id: 2, name: "bar")]
-      expect(subject[:third].error).to eq(error["error"])
+      it "skips raising an error while trying to access the query result if so directed" do
+        expect(Array(@subject[:first])).to eq [klass.new(_id: 1, name: "foo"), klass.new(_id: 2, name: "bar")]
+        expect(@subject[:third].error).to eq(error["error"])
+      end
+
+      it "knows which elements of the results are valid" do
+        expect(@subject[:first].valid?).to be true
+        expect(@subject[:second].valid?).to be true
+        expect(@subject[:third].valid?).to be false
+      end
     end
   end
 end


### PR DESCRIPTION
PT story: https://www.pivotaltracker.com/story/show/155727289

associated Doximity PR https://github.com/doximity/doximity/pull/23963

updated a source gem version because a spec was failing with the older version https://github.com/elastic/elasticsearch-ruby/blob/master/CHANGELOG.md#504

to more correctly mimic the `_msearch` API, allow `msearch`  to return the errors about an index rather than raising  an exception.
This will let the consumers of the API  display results from the other indexes of the `msearch`  and handle errors on their side.

Also return a 'null' result set along with the error and exception info so the consumer can more gracefully  handle the errors without additional case discrimination
