### PR TITLE
deleting with a wildcard is a risky setting that can be disabled

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v0.11.1
+  - support `action.destructive_requires_name` setting by being explict about which indices to delete
+
 v0.11.0
   - compatibilty with ES v6
     - change mappings for 'index' to boolean. "string" type was replaced with "text"

--- a/lib/elasticity/index_config.rb
+++ b/lib/elasticity/index_config.rb
@@ -30,7 +30,7 @@ module Elasticity
     def definition
       return @definition if defined?(@definition)
       @definition = {
-        settings: merge_settings, mappings: { @document_type => @mapping&.deep_stringify_keys || {} }
+        settings: merge_settings, mappings: { @document_type => @mapping.nil? ? {} : @mapping.deep_stringify_keys }
       }
       subclasses.each do |doc_type, subclass|
         @definition[:mappings][doc_type] = subclass.constantize.mapping

--- a/lib/elasticity/strategies/alias_index.rb
+++ b/lib/elasticity/strategies/alias_index.rb
@@ -186,7 +186,9 @@ module Elasticity
       end
 
       def delete
-        @client.index_delete(index: "#{@main_alias}-*")
+        main_indexes.each do |index|
+          @client.index_delete(index: index)
+        end
       end
 
       def delete_if_defined

--- a/lib/elasticity/strategies/alias_index.rb
+++ b/lib/elasticity/strategies/alias_index.rb
@@ -204,7 +204,7 @@ module Elasticity
         res = @client.index(index: @update_alias, type: type, id: id, body: attributes)
 
         if id = res["_id"]
-          [id, res.dig("_shards", "successful").to_i > 0]
+          [id, res["_shards"] && res["_shards"]["successful"].to_i > 0]
         else
           raise IndexError.new(@update_alias, "failed to index document. Response: #{res.inspect}")
         end

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = "0.11.0"
+  VERSION = "0.11.1bfdeletesnowildcard"
 end

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = "0.11.1bfdeletesnowildcard"
+  VERSION = "0.11.1"
 end


### PR DESCRIPTION
a wildcard is still used to identify which indices to delete, but enabling destructive_requires_name is still safer because ad hoc scripts can't perform wildcard deletes