### PR TITLE
Add Explain Option for es-elasticity

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v0.11.2
+ - Adds support for passing arguments to Search definition through `search(query, search_args)` in index searching and msearch
+ - adds _explanation to hold value of returned explanations in the base document
+
 v0.11.1
   - support `action.destructive_requires_name` setting by being explict about which indices to delete
 

--- a/README.md
+++ b/README.md
@@ -206,9 +206,9 @@ search_b = SearchDoc::B.search(query_body, { explain: true })
 search_c = SearchDoc::C.search(query_body, { explain: true })
 
 multi = Elasticity::MultiSearch.new do |m|
-  m.add( :a, search_a, documents: ::SearchDoc::A)
-  m.add( :b, search_b, documents: ::SearchDoc::B)
-  m.add( :c, search_c, documents: ::SearchDoc::C)
+  m.add(:a, search_a, documents: ::SearchDoc::A)
+  m.add(:b, search_b, documents: ::SearchDoc::B)
+  m.add(:c, search_c, documents: ::SearchDoc::C)
 end
 ```
 For more information about the `active_records` method, read [ActiveRecord integration](#activerecord-integration).

--- a/README.md
+++ b/README.md
@@ -191,6 +191,26 @@ cursor.each { |doc| ... }
 adults = adults.active_records(User)
 ```
 
+#### Search Args
+
+##### explain: true
+For `search` definitions we support passing  `{ explain: true }` to the search as a second argument in order to surface the reason a search result was returned. 
+
+```ruby
+# example in single search
+search_results_with_explanation = SearchDoc::A.search(query_body, { explain: true }).search_results
+
+# In multisearch
+search_a = SearchDoc::A.search(query_body, { explain: true })
+search_b = SearchDoc::B.search(query_body, { explain: true })
+search_c = SearchDoc::C.search(query_body, { explain: true })
+
+multi = Elasticity::MultiSearch.new do |m|
+  m.add( :a, search_a, documents: ::SearchDoc::A)
+  m.add( :b, search_b, documents: ::SearchDoc::B)
+  m.add( :c, search_c, documents: ::SearchDoc::C)
+end
+```
 For more information about the `active_records` method, read [ActiveRecord integration](#activerecord-integration).
 
 ### Segmented Documents

--- a/lib/elasticity/base_document.rb
+++ b/lib/elasticity/base_document.rb
@@ -12,7 +12,7 @@ module Elasticity
     end
 
     # Define common attributes for all documents
-    attr_accessor :_id, :highlighted, :_score, :sort
+    attr_accessor :_id, :highlighted, :_score, :sort, :_explanation
 
     def attributes=(attributes)
       attributes.each do |attr, value|

--- a/lib/elasticity/search.rb
+++ b/lib/elasticity/search.rb
@@ -29,11 +29,11 @@ module Elasticity
       end
 
       def to_search_args
-        { index: @index_name, type: @document_types, body: @body }.reverse_merge(@search_args)
+        @search_args.merge({ index: @index_name, type: @document_types, body: @body })
       end
 
       def to_msearch_args
-        search_body = @body.reverse_merge(@search_args)
+        search_body = @search_args.merge(@body)
 
         { index: @index_name, type: @document_types, search: search_body }
       end

--- a/lib/elasticity/search.rb
+++ b/lib/elasticity/search.rb
@@ -14,7 +14,7 @@ module Elasticity
         @index_name     = index_name
         @document_types = document_types
         @body           = body.deep_symbolize_keys!
-        @search_args = search_args
+        @search_args    = search_args
       end
 
       def update(body_changes)
@@ -47,10 +47,9 @@ module Elasticity
 
       # Creates a new facade for the given search definition, providing a set of helper methods
       # to trigger different type of searches and results interpretation.
-      def initialize(client, search_definition, search_args = {})
+      def initialize(client, search_definition)
         @client            = client
         @search_definition = search_definition
-        @search_args    = search_args
       end
 
       # Performs the search using the default search type and returning an iterator that will yield

--- a/lib/elasticity/search.rb
+++ b/lib/elasticity/search.rb
@@ -1,7 +1,7 @@
 module Elasticity
   module Search
-    def self.build(client, index_name, document_types, body)
-      search_def = Search::Definition.new(index_name, document_types, body)
+    def self.build(client, index_name, document_types, body, search_args = {})
+      search_def = Search::Definition.new(index_name, document_types, body, search_args)
       Search::Facade.new(client, search_def)
     end
 
@@ -10,10 +10,11 @@ module Elasticity
     class Definition
       attr_accessor :index_name, :document_types, :body
 
-      def initialize(index_name, document_types, body)
+      def initialize(index_name, document_types, body, search_args = {})
         @index_name     = index_name
         @document_types = document_types
         @body           = body.deep_symbolize_keys!
+        @search_args = search_args
       end
 
       def update(body_changes)
@@ -28,11 +29,13 @@ module Elasticity
       end
 
       def to_search_args
-        { index: @index_name, type: @document_types, body: @body }
+        { index: @index_name, type: @document_types, body: @body }.reverse_merge(@search_args)
       end
 
       def to_msearch_args
-        { index: @index_name, type: @document_types, search: @body }
+        search_body = @body.reverse_merge(@search_args)
+
+        { index: @index_name, type: @document_types, search: search_body }
       end
     end
 
@@ -44,9 +47,10 @@ module Elasticity
 
       # Creates a new facade for the given search definition, providing a set of helper methods
       # to trigger different type of searches and results interpretation.
-      def initialize(client, search_definition)
+      def initialize(client, search_definition, search_args = {})
         @client            = client
         @search_definition = search_definition
+        @search_args    = search_args
       end
 
       # Performs the search using the default search type and returning an iterator that will yield

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = "0.11.2.pre"
+  VERSION = "0.11.2"
 end

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = "0.11.1"
+  VERSION = "0.11.2.pre"
 end

--- a/spec/functional/persistence_spec.rb
+++ b/spec/functional/persistence_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "Persistence", elasticsearch: true do
         c.strategy = Elasticity::Strategies::SingleIndex
         c.document_type  = "cat"
         c.mapping = { "properties" => {
-          name: { type: "string", index: "not_analyzed" },
+          name: { type: "text", index: "not_analyzed" },
           age: { type: "integer" }
         } }
       end
@@ -104,7 +104,7 @@ RSpec.describe "Persistence", elasticsearch: true do
         c.strategy = Elasticity::Strategies::SingleIndex
         c.document_type = "dog"
         c.mapping = { "properties" => {
-          name: { type: "string", index: "not_analyzed" },
+          name: { type: "text", index: "not_analyzed" },
           age: { type: "integer" },
           hungry: { type: "boolean" }
         } }
@@ -167,7 +167,7 @@ RSpec.describe "Persistence", elasticsearch: true do
           c.mapping = {
             "properties" => {
               id: { type: "integer" },
-              name: { type: "string", index: "not_analyzed" },
+              name: { type: "text", index: "not_analyzed" },
               birthdate: { type: "date" },
             },
           }
@@ -268,7 +268,7 @@ RSpec.describe "Persistence", elasticsearch: true do
           c.mapping = {
             "properties" => {
               id: { type: "integer" },
-              name: { type: "string", index: "not_analyzed" },
+              name: { type: "text", index: "not_analyzed" },
             },
           }
         end

--- a/spec/functional/search_spec.rb
+++ b/spec/functional/search_spec.rb
@@ -1,0 +1,82 @@
+RSpec.describe "Search", elasticsearch: true do
+  describe "multi mapping index" do
+    class Cat < Elasticity::Document
+      configure do |c|
+        c.index_base_name = "cats"
+        c.strategy = Elasticity::Strategies::SingleIndex
+        c.document_type  = "cat"
+        c.mapping = { "properties" => {
+          name: { type: "keyword" },
+          age: { type: "integer" }
+        } }
+      end
+
+      attr_accessor :name, :age
+
+      def to_document
+        { name: name, age: age }
+      end
+    end
+
+    class Dog < Elasticity::Document
+      configure do |c|
+        c.index_base_name = "dogs"
+        c.strategy = Elasticity::Strategies::SingleIndex
+        c.document_type = "dog"
+        c.mapping = { "properties" => {
+          name: { type: "keyword" },
+          age: { type: "integer" },
+          hungry: { type: "boolean" }
+        } }
+      end
+      attr_accessor :name, :age, :hungry
+
+      def to_document
+        { name: name, age: age, hungry: hungry }
+      end
+    end
+
+    describe "search_args" do
+      before do
+        Cat.recreate_index
+        Dog.recreate_index
+
+        @elastic_search_client.cluster.health wait_for_status: 'yellow'
+
+        cat = Cat.new(name: "felix", age: 10)
+        dog = Dog.new(name: "fido", age: 4, hungry: true)
+
+        cat.update
+        dog.update
+
+        Cat.flush_index
+      end
+
+      describe "explain: true" do
+        def get_explanations(results)
+          results.map(&:_explanation)
+        end
+
+        it "supports on single search index" do
+          results = Cat.search({}, { explain: true }).search_results
+
+          expect(get_explanations(results)).to all( be_truthy )
+          # expect(results.first._explanation).to_not be_nil
+        end
+
+        it "supports for multisearch" do
+          cat = Cat.search({}, { explain: true })
+          dog = Dog.search({})
+
+          subject = Elasticity::MultiSearch.new do |m|
+            m.add(:cats, cat, documents: Cat)
+            m.add(:dogs, dog, documents: Dog)
+          end
+
+          expect(get_explanations(subject[:cats])).to all( be_truthy )
+          expect(get_explanations(subject[:dogs])).to all( be_nil )
+        end
+      end
+    end
+  end
+end

--- a/spec/functional/search_spec.rb
+++ b/spec/functional/search_spec.rb
@@ -1,78 +1,76 @@
 RSpec.describe "Search", elasticsearch: true do
-  describe "multi mapping index" do
-    class CatDoc < Elasticity::Document
-      configure do |c|
-        c.strategy = Elasticity::Strategies::SingleIndex
-        c.document_type  = "cat"
-        c.mapping = { "properties" => {
-          name: { type: "keyword" },
-          age: { type: "integer" }
-        } }
-      end
-
-      attr_accessor :name, :age
-
-      def to_document
-        { name: name, age: age }
-      end
+  class CatDoc < Elasticity::Document
+    configure do |c|
+      c.strategy = Elasticity::Strategies::SingleIndex
+      c.document_type  = "cat"
+      c.mapping = { "properties" => {
+        name: { type: "keyword" },
+        age: { type: "integer" }
+      } }
     end
 
-    class DogDoc < Elasticity::Document
-      configure do |c|
-        c.strategy = Elasticity::Strategies::SingleIndex
-        c.document_type = "dog"
-        c.mapping = { "properties" => {
-          name: { type: "keyword" },
-          age: { type: "integer" },
-          hungry: { type: "boolean" }
-        } }
-      end
-      attr_accessor :name, :age, :hungry
+    attr_accessor :name, :age
 
-      def to_document
-        { name: name, age: age, hungry: hungry }
-      end
+    def to_document
+      { name: name, age: age }
+    end
+  end
+
+  class DogDoc < Elasticity::Document
+    configure do |c|
+      c.strategy = Elasticity::Strategies::SingleIndex
+      c.document_type = "dog"
+      c.mapping = { "properties" => {
+        name: { type: "keyword" },
+        age: { type: "integer" },
+        hungry: { type: "boolean" }
+      } }
+    end
+    attr_accessor :name, :age, :hungry
+
+    def to_document
+      { name: name, age: age, hungry: hungry }
+    end
+  end
+
+  describe "search_args" do
+    before do
+      CatDoc.recreate_index
+      DogDoc.recreate_index
+
+      @elastic_search_client.cluster.health wait_for_status: 'yellow'
+
+      cat = CatDoc.new(name: "felix", age: 10)
+      dog = DogDoc.new(name: "fido", age: 4, hungry: true)
+
+      cat.update
+      dog.update
+
+      CatDoc.flush_index
     end
 
-    describe "search_args" do
-      before do
-        CatDoc.recreate_index
-        DogDoc.recreate_index
-
-        @elastic_search_client.cluster.health wait_for_status: 'yellow'
-
-        cat = CatDoc.new(name: "felix", age: 10)
-        dog = DogDoc.new(name: "fido", age: 4, hungry: true)
-
-        cat.update
-        dog.update
-
-        CatDoc.flush_index
+    describe "explain: true" do
+      def get_explanations(results)
+        results.map(&:_explanation)
       end
 
-      describe "explain: true" do
-        def get_explanations(results)
-          results.map(&:_explanation)
+      it "supports on single index search results" do
+        results = CatDoc.search({}, { explain: true }).search_results
+
+        expect(get_explanations(results)).to all( be_truthy )
+      end
+
+      it "supports for multisearch" do
+        cat = CatDoc.search({}, { explain: true })
+        dog = DogDoc.search({})
+
+        subject = Elasticity::MultiSearch.new do |m|
+          m.add(:cats, cat, documents: CatDoc)
+          m.add(:dogs, dog, documents: DogDoc)
         end
 
-        it "supports on single index search results" do
-          results = CatDoc.search({}, { explain: true }).search_results
-
-          expect(get_explanations(results)).to all( be_truthy )
-        end
-
-        it "supports for multisearch" do
-          cat = CatDoc.search({}, { explain: true })
-          dog = DogDoc.search({})
-
-          subject = Elasticity::MultiSearch.new do |m|
-            m.add(:cats, cat, documents: CatDoc)
-            m.add(:dogs, dog, documents: DogDoc)
-          end
-
-          expect(get_explanations(subject[:cats])).to all( be_truthy )
-          expect(get_explanations(subject[:dogs])).to all( be_nil )
-        end
+        expect(get_explanations(subject[:cats])).to all( be_truthy )
+        expect(get_explanations(subject[:dogs])).to all( be_nil )
       end
     end
   end


### PR DESCRIPTION
Adds the ability to request a `explain: true` on multisearch and regular searches.

Closes #47 

### Proposed API for specifying explain
```ruby
# example in single search
search_with_explanation = SearchDoc.search(query_body, { explain: true }).search_results

# In multisearch
search_a = SearchDoc::A.search(query_body, { explain: true })
search_b = SearchDoc::B.search(query_body, { explain: true })
search_c = SearchDoc::C.search(query_body, { explain: true })

multi = Elasticity::MultiSearch.new do |m|
  m.add( :a, search_a, documents: ::SearchDoc::A)
  m.add( :b, search_b, documents: ::SearchDoc::B)
  m.add( :c, search_c, documents: ::SearchDoc::C)
end
```

### Detailed Changes
 - adds the ability to add search arguments to an elasticsearch query in both single index and multisearch queries.  
 - implements `explain: true` 
 - exposes `_explanation` as a public attr_reader on search and sets its value when it is present on search results

