### PR TITLE
Add ability to expose "highlight" to client

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v0.11.3
+ - Adds support for preserving the order or normalized names of `highlight` through `highlighted_attrs`
+
 v0.11.2
  - Adds support for passing arguments to Search definition through `search(query, search_args)` in index searching and msearch
  - adds _explanation to hold value of returned explanations in the base document

--- a/lib/elasticity/base_document.rb
+++ b/lib/elasticity/base_document.rb
@@ -12,7 +12,7 @@ module Elasticity
     end
 
     # Define common attributes for all documents
-    attr_accessor :_id, :highlighted, :_score, :sort, :_explanation, :highlight
+    attr_accessor :_id, :highlighted, :_score, :sort, :_explanation, :highlighted_attrs
 
     def attributes=(attributes)
       attributes.each do |attr, value|

--- a/lib/elasticity/base_document.rb
+++ b/lib/elasticity/base_document.rb
@@ -12,7 +12,7 @@ module Elasticity
     end
 
     # Define common attributes for all documents
-    attr_accessor :_id, :highlighted, :_score, :sort, :_explanation
+    attr_accessor :_id, :highlighted, :_score, :sort, :_explanation, :highlight
 
     def attributes=(attributes)
       attributes.each do |attr, value|

--- a/lib/elasticity/index_mapper.rb
+++ b/lib/elasticity/index_mapper.rb
@@ -144,15 +144,14 @@ module Elasticity
       attrs.merge!(hit["_source"]) if hit["_source"]
 
       if hit["highlight"]
-        hit["highlight"]["name.foo"] = ["o"]
-
         highlighted_attrs = attrs.dup
-        ordered_set = hit["highlight"].each_with_object([]) do |(name, value), set|
-          name = name.gsub(/\..*\z/, '')
-          next if set.any? { |item| item.has_key?(name.to_sym) }
+        highlighted_attr_names = []
 
-          set.push({ "#{name}": value })
-          highlighted_attrs[name] = value
+        hit["highlight"].each do |name, v|
+          name = name.gsub(/\..*\z/, '')
+          next if highlighted_attr_names.include?(name)
+          highlighted_attrs[name] = v
+          highlighted_attr_names << name
         end
 
         highlighted = @document_klass.new(highlighted_attrs)
@@ -160,7 +159,7 @@ module Elasticity
 
       injected_attrs = attrs.merge({
         highlighted: highlighted,
-        highlighted_attrs: ordered_set,
+        highlighted_attrs: highlighted_attr_names,
         _explanation: hit["_explanation"]
       })
 

--- a/lib/elasticity/index_mapper.rb
+++ b/lib/elasticity/index_mapper.rb
@@ -143,23 +143,21 @@ module Elasticity
       attrs.merge!(sort: hit["sort"])
       attrs.merge!(hit["_source"]) if hit["_source"]
 
-      if hit["highlight"]
-        highlighted_attrs = attrs.dup
-        highlighted_attr_names = []
+      highlighted = nil
 
-        hit["highlight"].each do |name, v|
+      if hit["highlight"]
+        highlighted_attrs = hit["highlight"].each_with_object({}) do |(name, v), attrs|
           name = name.gsub(/\..*\z/, '')
-          next if highlighted_attr_names.include?(name)
-          highlighted_attrs[name] = v
-          highlighted_attr_names << name
+
+          attrs[name] ||= v
         end
 
-        highlighted = @document_klass.new(highlighted_attrs)
+        highlighted = @document_klass.new(attrs.merge(highlighted_attrs))
       end
 
       injected_attrs = attrs.merge({
         highlighted: highlighted,
-        highlighted_attrs: highlighted_attr_names,
+        highlighted_attrs: highlighted_attrs.try(:keys),
         _explanation: hit["_explanation"]
       })
 

--- a/lib/elasticity/index_mapper.rb
+++ b/lib/elasticity/index_mapper.rb
@@ -159,6 +159,7 @@ module Elasticity
 
       injected_attrs = attrs.merge({
         highlighted: highlighted,
+        highlight: hit["highlight"],
         _explanation: hit["_explanation"]
       })
 

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = "0.11.3.beta.0"
+  VERSION = "0.11.3"
 end

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = "0.11.2"
+  VERSION = "0.11.3.beta.0"
 end

--- a/spec/functional/search_spec.rb
+++ b/spec/functional/search_spec.rb
@@ -104,8 +104,7 @@ RSpec.describe "Search", elasticsearch: true do
         }
 
         it "highlighted_attrs returns the highlighted" do
-          expect(cat_search_result.highlighted_attrs[0].keys).to eq([:name])
-          expect(cat_search_result.highlighted_attrs[1].keys).to eq([:description])
+          expect(cat_search_result.highlighted_attrs).to eq(["name", "description"])
         end
 
         it "highlighted returns a new object with the name transformed" do


### PR DESCRIPTION
This PR adds a new attribute that gives es-elasticity the ability to preserve the general structure of request fields that are highlighted by Elasticsearch.

### Current Implementation
When the client requests fields to be highlighted from elasticsearch, IndexMapper will grab those highlighted fields and merge them directly into a new object so that the client can directly access the highlighted fields on the object when the result is returned.

```
# Example Response 
{
  description: "foo",
  highlight: [
    { foo: ["<em>foo</em>"] }
  ]
}

document.foo => "foo"
document.highlighted.foo => ["<em>foo</em>"]
```

### Justification

The current approach is great when we have a 1 to 1 mapping between what the client cares about and what elasticsearch is matching.  But we need to expose the highlight in order to either
 - Displaying a subset on the view that *may* not return results from es.  For example, having a presented value of `full_name_with_special_formatting` on the view and we matched the query on `first_name`.
 - Need to identify the cause of a result surfacing based on relevancy score.  For instance, showing cards with only name and location but a match was on something more granular that is not displayed.

### Implementation

We expose a new attribute on the Base class `highlighted_attrs` that is an ordered set of the highlighted attributes that are returned from Elasticsearch.  It follows the same normalization rules as `highlighted`.

```
{
  description: "foo",
  highlight: [
    { foo: ["<em>foo</em>"] }
  ]
}

document.highlighted_attrs =>  ["foo"]
document.highlighted.foo => ["<em>foo</em>"]
```