### PR TITLE
159957541 fully clean up after error during remap

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-v0.11.4.pre
+v0.11.4
  - Fully clean up if error occurs during remap (assign all aliases back to original index)
 v0.11.3
  - Adds support for preserving the order or normalized names of `highlight` through `highlighted_attrs`

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+v0.11.4.pre
+ - Fully clean up if error occurs during remap (assign all aliases back to original index)
 v0.11.3
  - Adds support for preserving the order or normalized names of `highlight` through `highlighted_attrs`
 

--- a/lib/elasticity/strategies/alias_index.rb
+++ b/lib/elasticity/strategies/alias_index.rb
@@ -104,6 +104,7 @@ module Elasticity
         rescue
           @client.index_update_aliases(body: {
             actions: [
+              { add:    { index: original_index, alias: @main_alias } },
               { add:    { index: original_index, alias: @update_alias } },
               { remove: { index: new_index, alias: @update_alias } },
             ]

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = "0.11.3"
+  VERSION = "0.11.4.pre"
 end

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = "0.11.4.pre"
+  VERSION = "0.11.4"
 end

--- a/spec/functional/persistence_spec.rb
+++ b/spec/functional/persistence_spec.rb
@@ -313,6 +313,21 @@ RSpec.describe "Persistence", elasticsearch: true do
       expect(results.total).to eq(2010)
     end
 
+    it "fully cleans up if error occurs deleting the old index during remap" do
+      expected_aliases = %w[elasticity_test_users elasticity_test_users_update]
+      original_aliases = all_aliases(subject)
+      expect(original_aliases).to match_array(expected_aliases)
+      number_of_docs = 20
+      number_of_docs.times.map do |i|
+        subject.new(id: i, name: "User #{i}", birthdate: random_birthdate).tap(&:update)
+      end
+      allow_any_instance_of(Elasticity::InstrumentedClient).to receive(:index_delete).and_raise("KAPOW")
+
+      expect { subject.remap! }.to raise_error("KAPOW")
+      cleaned_up_aliases = all_aliases(subject)
+      expect(cleaned_up_aliases).to match_array(expected_aliases)
+    end
+
     it "bulk indexes, updates and delete" do
       docs = 2000.times.map do |i|
         subject.new(_id: i, id: i, name: "User #{i}", birthdate: random_birthdate).tap(&:update)
@@ -341,5 +356,10 @@ RSpec.describe "Persistence", elasticsearch: true do
       results = subject.search(from: 0, size: 3000)
       expect(results.total).to eq 0
     end
+  end
+
+  def all_aliases(subj)
+    base_name = subj.ref_index_name
+    subj.config.client.index_get_alias(index: "#{base_name}-*", name: "#{base_name}*").values.first["aliases"].keys
   end
 end

--- a/spec/functional/persistence_spec.rb
+++ b/spec/functional/persistence_spec.rb
@@ -321,11 +321,14 @@ RSpec.describe "Persistence", elasticsearch: true do
       number_of_docs.times.map do |i|
         subject.new(id: i, name: "User #{i}", birthdate: random_birthdate).tap(&:update)
       end
-      allow_any_instance_of(Elasticity::InstrumentedClient).to receive(:index_delete).and_raise("KAPOW")
 
-      expect { subject.remap! }.to raise_error("KAPOW")
+      allow_any_instance_of(Elasticity::InstrumentedClient).to receive(:index_delete).and_raise("KAPOW")
+      expect do
+        subject.remap!
+      end.to raise_error("KAPOW")
       cleaned_up_aliases = all_aliases(subject)
       expect(cleaned_up_aliases).to match_array(expected_aliases)
+      allow_any_instance_of(Elasticity::InstrumentedClient).to receive(:index_delete).and_call_original
     end
 
     it "bulk indexes, updates and delete" do

--- a/spec/functional/persistence_spec.rb
+++ b/spec/functional/persistence_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "Persistence", elasticsearch: true do
         c.strategy = Elasticity::Strategies::SingleIndex
         c.document_type  = "cat"
         c.mapping = { "properties" => {
-          name: { type: "text", index: "not_analyzed" },
+          name: { type: "text", index: true },
           age: { type: "integer" }
         } }
       end
@@ -104,7 +104,7 @@ RSpec.describe "Persistence", elasticsearch: true do
         c.strategy = Elasticity::Strategies::SingleIndex
         c.document_type = "dog"
         c.mapping = { "properties" => {
-          name: { type: "text", index: "not_analyzed" },
+          name: { type: "text", index: true },
           age: { type: "integer" },
           hungry: { type: "boolean" }
         } }
@@ -167,7 +167,7 @@ RSpec.describe "Persistence", elasticsearch: true do
           c.mapping = {
             "properties" => {
               id: { type: "integer" },
-              name: { type: "text", index: "not_analyzed" },
+              name: { type: "text", index: true },
               birthdate: { type: "date" },
             },
           }
@@ -268,7 +268,7 @@ RSpec.describe "Persistence", elasticsearch: true do
           c.mapping = {
             "properties" => {
               id: { type: "integer" },
-              name: { type: "text", index: "not_analyzed" },
+              name: { type: "text", index: true },
             },
           }
         end


### PR DESCRIPTION
Pivotal Tracker Story: https://www.pivotaltracker.com/story/show/159957541

associated Doximity PR https://github.com/doximity/doximity/pull/26007

errors during a `remap`, specifically trying to delete the index whilst a snapshot was in progress,  were leaving the cluster in a bad state

```
[404] {"error":{"root_cause":[{"type":"index_not_found_exception","reason":"no such index","resource.type":"index_or_alias","resource.id":"production_user_documents","index_uuid":"_na_","index":"production_user_documents"}],"type":"index_not_found_exception","reason":"no such index","resource.type":"index_or_alias","resource.id":"production_user_documents","index_uuid":"_na_","index":"production_user_documents"},"status":404}
```

This was because the main alias as not getting pointed back to the original index during clean-up.
It was removed on [line 97](https://github.com/doximity/es-elasticity/compare/159957541_fully_clean_up_after_error_during_remap?expand=1#diff-61da289017228864edc1d8b8579abda8R97)  but was not being restored