### PR TITLE
retry deleting the index after certain exceptions during remap

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
-v0.11.4.pre
+v0.11.5.pre
+ - Give the option of retrying the deletion for certain exceptions during remap
+v0.11.4
  - Fully clean up if error occurs during remap (assign all aliases back to original index)
 v0.11.3
  - Adds support for preserving the order or normalized names of `highlight` through `highlighted_attrs`

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-v0.11.5.pre
+v0.11.5
  - Give the option of retrying the deletion for certain exceptions during remap
 v0.11.4
  - Fully clean up if error occurs during remap (assign all aliases back to original index)

--- a/lib/elasticity/index_mapper.rb
+++ b/lib/elasticity/index_mapper.rb
@@ -65,8 +65,9 @@ module Elasticity
     end
 
     # Remap
-    def remap!
-      @strategy.remap(@index_config.definition)
+    # retry_delay & max_delay are in seconds
+    def remap!(retry_on_recoverable_errors: true, retry_delay: 30, max_delay: 600)
+      @strategy.remap(@index_config.definition, retry_on_recoverable_errors, retry_delay, max_delay)
     end
 
     # Flushes the index, forcing any writes

--- a/lib/elasticity/index_mapper.rb
+++ b/lib/elasticity/index_mapper.rb
@@ -66,8 +66,8 @@ module Elasticity
 
     # Remap
     # retry_delay & max_delay are in seconds
-    def remap!(retry_on_recoverable_errors: true, retry_delay: 30, max_delay: 600)
-      @strategy.remap(@index_config.definition, retry_on_recoverable_errors, retry_delay, max_delay)
+    def remap!(retry_delete_on_recoverable_errors: true, retry_delay: 30, max_delay: 600)
+      @strategy.remap(@index_config.definition, retry_delete_on_recoverable_errors: retry_delete_on_recoverable_errors, retry_delay: retry_delay, max_delay: max_delay)
     end
 
     # Flushes the index, forcing any writes

--- a/lib/elasticity/strategies/alias_index.rb
+++ b/lib/elasticity/strategies/alias_index.rb
@@ -33,7 +33,7 @@ module Elasticity
       #
       # It does a little bit more to ensure consistency and to handle race-conditions. For more details
       # look at the implementation.
-      def remap(index_def, retry_on_recoverable_errors = false, retry_delay = 0, max_delay = 0)
+      def remap(index_def, retry_delete_on_recoverable_errors: false, retry_delay: 0, max_delay: 0)
         main_indexes   = self.main_indexes
         update_indexes = self.update_indexes
 
@@ -108,7 +108,7 @@ module Elasticity
           begin
             @client.index_delete(index: original_index)
           rescue Elasticsearch::Transport::Transport::ServerError => e
-            if retryable?(e)  && retry_on_recoverable_errors && waiting_duration < max_delay
+            if retryable_error?(e)  && retry_delete_on_recoverable_errors && waiting_duration < max_delay
               waiting_duration += retry_delay
               sleep(retry_delay)
               retry
@@ -285,7 +285,7 @@ module Elasticity
         index_name
       end
 
-      def retryable?(e)
+      def retryable_error?(e)
         RETRYABLE_ERROR_SNIPPETS.any? do |s|
           e.message.match(s)
         end

--- a/lib/elasticity/strategies/alias_index.rb
+++ b/lib/elasticity/strategies/alias_index.rb
@@ -4,9 +4,10 @@ module Elasticity
     # runtime changes by simply atomically updating the aliases. For example, look at the remap method
     # implementation.
     class AliasIndex
+      SNAPSHOT_ERROR_SNIPPET =  "Cannot delete indices that are being snapshotted".freeze
       RETRYABLE_ERROR_SNIPPETS = [
-        "Cannot delete indices that are being snapshotted"
-      ]
+        SNAPSHOT_ERROR_SNIPPET
+      ].freeze
 
       STATUSES = [:missing, :ok]
 

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = "0.11.4.pre"
+  VERSION = "0.11.5.pre"
 end

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = "0.11.5.pre"
+  VERSION = "0.11.5"
 end

--- a/spec/functional/persistence_spec.rb
+++ b/spec/functional/persistence_spec.rb
@@ -85,6 +85,7 @@ RSpec.describe "Persistence", elasticsearch: true do
         c.index_base_name = "cats_and_dogs"
         c.strategy = Elasticity::Strategies::SingleIndex
         c.document_type  = "cat"
+
         c.mapping = { "properties" => {
           name: { type: "text", index: true },
           age: { type: "integer" }
@@ -331,6 +332,70 @@ RSpec.describe "Persistence", elasticsearch: true do
       allow_any_instance_of(Elasticity::InstrumentedClient).to receive(:index_delete).and_call_original
     end
 
+    context "recovering from remap errors" do
+      let(:recoverable_message) do
+        '[400] {"error":{"root_cause":[{"type":"remote_transport_exception","reason":"[your_cluster][cluster_id][indices:admin/delete]"}],"type":"illegal_argument_exception","reason":"Cannot delete indices that are being snapshotted: [[full_index_name_and_id]]. Try again after snapshot finishes or cancel the currently running snapshot."},"status":400}'
+      end
+      after do
+        allow_any_instance_of(Elasticity::InstrumentedClient).to receive(:index_delete).and_call_original
+      end
+
+      it "waits for recoverable errors before deleting old index during remap" do
+        original_index_name = subject.config.client.index_get_alias(index: "#{subject.ref_index_name}-*", name: subject.ref_index_name).keys.first
+
+        call_count = 0
+        allow_any_instance_of(Elasticity::InstrumentedClient).to receive(:index_delete) do
+          call_count +=1
+          if call_count < 3
+            raise Elasticsearch::Transport::Transport::Errors::BadRequest.new(recoverable_message)
+          else
+            []
+          end
+        end
+        build_some_docs(subject)
+
+        subject.remap!(retry_on_recoverable_errors: true, retry_delay: 0.5, max_delay: 1)
+        subject.flush_index
+        results = subject.search({})
+        expect(results.total).to eq(20)
+        remapped_index_name = subject.config.client.index_get_alias(index: "#{subject.ref_index_name}-*", name: subject.ref_index_name).keys.first
+        expect(remapped_index_name).to_not eq(original_index_name)
+      end
+
+      it "will only retry for a set amount of time" do
+        allow_any_instance_of(Elasticity::InstrumentedClient).to receive(:index_delete).and_raise(
+          Elasticsearch::Transport::Transport::Errors::BadRequest.new(recoverable_message)
+        )
+        build_some_docs(subject)
+        expect {
+          subject.remap!(retry_on_recoverable_errors: true, retry_delay: 0.5, max_delay: 1)
+        }.to raise_error(Elasticsearch::Transport::Transport::ServerError)
+      end
+
+      it "will not only retry if the arguments say not to" do
+        original_index_name = subject.config.client.index_get_alias(index: "#{subject.ref_index_name}-*", name: subject.ref_index_name).keys.first
+        allow_any_instance_of(Elasticity::InstrumentedClient).to receive(:index_delete).with(any_args).and_call_original
+        allow_any_instance_of(Elasticity::InstrumentedClient).to receive(:index_delete).with(index: original_index_name).and_raise(
+          Elasticsearch::Transport::Transport::Errors::BadRequest.new(recoverable_message)
+        )
+        build_some_docs(subject)
+        expect {
+          subject.remap!(retry_on_recoverable_errors: false)
+        }.to raise_error(Elasticsearch::Transport::Transport::ServerError)
+      end
+
+      it "will not retry for 'non-recoverable' errors" do
+        exception_message = '[404] {"error":"alias [some_index_name] missing","status":404}'
+        allow_any_instance_of(Elasticity::InstrumentedClient).to receive(:index_delete).and_raise(
+          Elasticsearch::Transport::Transport::Errors::BadRequest.new(exception_message)
+        )
+        build_some_docs(subject)
+        expect {
+          subject.remap!(retry_on_recoverable_errors: true, retry_delay: 0.5, max_delay: 1)
+        }.to raise_error(Elasticsearch::Transport::Transport::ServerError)
+      end
+    end
+
     it "bulk indexes, updates and delete" do
       docs = 2000.times.map do |i|
         subject.new(_id: i, id: i, name: "User #{i}", birthdate: random_birthdate).tap(&:update)
@@ -364,5 +429,11 @@ RSpec.describe "Persistence", elasticsearch: true do
   def all_aliases(subj)
     base_name = subj.ref_index_name
     subj.config.client.index_get_alias(index: "#{base_name}-*", name: "#{base_name}*").values.first["aliases"].keys
+  end
+
+  def build_some_docs(subj, doc_count = 20)
+    doc_count.times.map do |i|
+      subj.new(id: i, name: "User #{i}", birthdate: random_birthdate).tap(&:update)
+    end
   end
 end

--- a/spec/functional/persistence_spec.rb
+++ b/spec/functional/persistence_spec.rb
@@ -354,7 +354,7 @@ RSpec.describe "Persistence", elasticsearch: true do
         end
         build_some_docs(subject)
 
-        subject.remap!(retry_on_recoverable_errors: true, retry_delay: 0.5, max_delay: 1)
+        subject.remap!(retry_delete_on_recoverable_errors: true, retry_delay: 0.5, max_delay: 1)
         subject.flush_index
         results = subject.search({})
         expect(results.total).to eq(20)
@@ -368,7 +368,7 @@ RSpec.describe "Persistence", elasticsearch: true do
         )
         build_some_docs(subject)
         expect {
-          subject.remap!(retry_on_recoverable_errors: true, retry_delay: 0.5, max_delay: 1)
+          subject.remap!(retry_delete_on_recoverable_errors: true, retry_delay: 0.5, max_delay: 1)
         }.to raise_error(Elasticsearch::Transport::Transport::ServerError)
       end
 
@@ -380,7 +380,7 @@ RSpec.describe "Persistence", elasticsearch: true do
         )
         build_some_docs(subject)
         expect {
-          subject.remap!(retry_on_recoverable_errors: false)
+          subject.remap!(retry_delete_on_recoverable_errors: false)
         }.to raise_error(Elasticsearch::Transport::Transport::ServerError)
       end
 
@@ -391,7 +391,7 @@ RSpec.describe "Persistence", elasticsearch: true do
         )
         build_some_docs(subject)
         expect {
-          subject.remap!(retry_on_recoverable_errors: true, retry_delay: 0.5, max_delay: 1)
+          subject.remap!(retry_delete_on_recoverable_errors: true, retry_delay: 0.5, max_delay: 1)
         }.to raise_error(Elasticsearch::Transport::Transport::ServerError)
       end
     end


### PR DESCRIPTION
Pivotal Tracker story: https://www.pivotaltracker.com/story/show/160027841
related story https://www.pivotaltracker.com/story/show/159957541  and PR https://github.com/doximity/es-elasticity/pull/64


If a snapshot is in progress when we try to delete the old index
during a remap, the whole remap will fail. And it is only due to
bad timing.
That is an expensive errors since some remap can take 10s of hours.
So lets give the option of retrying that delete so we don't have
to waste all the cycles used during the remap