### PR TITLE
Remove destructive operation on search body

### DIFF
--- a/lib/elasticity/search.rb
+++ b/lib/elasticity/search.rb
@@ -13,7 +13,7 @@ module Elasticity
       def initialize(index_name, document_types, body, search_args = {})
         @index_name     = index_name
         @document_types = document_types
-        @body           = body.deep_symbolize_keys!
+        @body           = body.deep_symbolize_keys
         @search_args    = search_args
       end
 


### PR DESCRIPTION
The bang method is dangerous and doesn't let us pass frozen constants.