### PR TITLE
avoid unsafe sql with Arel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rvm:
 addons:
   apt:
     packages:
-      - oracle-java8-set-default
+      - openjdk-8-jre-headless
 before_script:
   - sleep 5
 env:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-v0.12.1.pre0
+v0.12.1
   - use Arel.sql to avoid unsafe sql and eliminate deprecation warnings when used in Rails projects
 v0.12.0
   - warn when configuring a index with subclasses if using ES version that does support them

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+v0.12.1.pre0
+  - use Arel.sql to avoid unsafe sql and eliminate deprecation warnings when used in Rails projects
 v0.12.0
   - warn when configuring a index with subclasses if using ES version that does support them
   - raise exception when creating or adding document to an index configured with subclasses if using

--- a/elasticity.gemspec
+++ b/elasticity.gemspec
@@ -31,5 +31,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activesupport", ">= 4.0.0", "< 6"
   spec.add_dependency "activemodel",   ">= 4.0.0", "< 6"
+  spec.add_dependency "activerecord",   ">= 4.0.0", "< 6"
   spec.add_dependency "elasticsearch", ">= 1.0"
 end

--- a/lib/elasticity.rb
+++ b/lib/elasticity.rb
@@ -17,6 +17,7 @@ require "bundler/setup"
 Bundler.setup
 
 require "active_support"
+require "arel"
 require "active_support/core_ext"
 require "active_model"
 require "elasticsearch"

--- a/lib/elasticity/search.rb
+++ b/lib/elasticity/search.rb
@@ -193,7 +193,7 @@ module Elasticity
         if ids.any?
           id_col  = "#{relation.connection.quote_column_name(relation.table_name)}.#{relation.connection.quote_column_name(relation.klass.primary_key)}"
           id_vals = ids.map { |id| relation.connection.quote(id) }
-          Relation.new(relation.where("#{id_col} IN (?)", ids).order("FIELD(#{id_col}, #{id_vals.join(',')})"), body, response)
+          Relation.new(relation.where("#{id_col} IN (?)", ids).order(Arel.sql("FIELD(#{id_col}, #{id_vals.join(',')})")), body, response)
         else
           Relation.new(relation.none, body, response)
         end

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = "0.12.0"
+  VERSION = "0.12.1.pre0"
 end

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = "0.12.1.pre0"
+  VERSION = "0.12.1"
 end


### PR DESCRIPTION
PT story https://www.pivotaltracker.com/story/show/167606136

Use `Arel.sql`  to avoid potentially unsafe sql (and quiet some deprecation warnings when used within a Rails project)