### PR TITLE
remove to_ary delegation WIP

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+v0.13.1
+  - remove superfluous 'to_ary' delegation that was causing issues downstream
 v0.13.0
   - changes needed for use with Elasticsearch v7
   - handle the v7 "total" as an object rather than a scalar

--- a/lib/elasticity/search.rb
+++ b/lib/elasticity/search.rb
@@ -87,7 +87,7 @@ module Elasticity
     class LazySearch
       include Enumerable
 
-      delegate :each, :size, :length, :[], :+, :-, :&, :|, :total, :per_page, :to_ary,
+      delegate :each, :size, :length, :[], :+, :-, :&, :|, :total, :per_page,
         :total_pages, :current_page, :next_page, :previous_page, :aggregations, to: :search_results
 
       attr_accessor :search_definition

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = "0.13.1.pre"
+  VERSION = "0.13.1"
 end

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = "0.13.0"
+  VERSION = "0.13.1.pre"
 end


### PR DESCRIPTION
PT story https://www.pivotaltracker.com/story/show/169371020

Overview
--------
Initial work for the v7.2 upgrade was done under https://github.com/doximity/es-elasticity/pull/69

But that version caused some errors in downstream users of the gem.  The source of those errors was traced to the delegation of `to_ary` in `LazySearch` class.  That delegation seemed to be serving no purpose that I could find so I have removed it.

see https://github.com/doximity/doximity/pull/30869



