### PR TITLE
Revert frozen string literal changes in 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [1.0.1] - 2022-08-16
 ### Changed
 - Revert the additional `frozen_string_literal` updates in 1.0.0 due to some issues with some classes. We'll update these 
-in a separate 
-release to isolate the problem.
+in a separate release to isolate the problem.
 
 ## [1.0.0] - 2022-08-09
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [1.0.1] - 2022-08-16
 ### Changed
-- Revert the additional `frozen_string_literal` updates in 1.0.0 due to some issues with some classes. We'll update these 
-in a separate release to isolate the problem.
+- Revert the additional `frozen_string_literal` updates in 1.0.0 due to some issues with some classes. We'll update these in a separate release to isolate the problem.
 
 ## [1.0.0] - 2022-08-09
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-## [1.0.1.jhumphreys] - 2022-08-16
+## [1.0.1] - 2022-08-16
 ### Changed
 - Revert changes frozen_string_literal in 1.0.0 due to some issues with some classes. We'll update these in a separate 
 release to isolate the problem.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [1.0.1] - 2022-08-16
 ### Changed
-- Revert changes frozen_string_literal in 1.0.0 due to some issues with some classes. We'll update these in a separate 
+- Revert the additional `frozen_string_literal` updates in 1.0.0 due to some issues with some classes. We'll update these 
+in a separate 
 release to isolate the problem.
 
 ## [1.0.0] - 2022-08-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [1.0.1.jhumphreys] - 2022-08-16
+### Changed
+- Revert changes frozen_string_literal in 1.0.0 due to some issues with some classes. We'll update these in a separate 
+release to isolate the problem.
+
 ## [1.0.0] - 2022-08-09
 ### Changed
 - Consistently use quotations

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    es-elasticity (1.0.0)
+    es-elasticity (1.0.1.jhumphreys)
       activemodel (>= 5.2.0, < 7.1)
       activerecord (>= 5.2.0, < 7.1)
       activesupport (>= 5.2.0, < 7.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    es-elasticity (1.0.1.jhumphreys)
+    es-elasticity (1.0.1)
       activemodel (>= 5.2.0, < 7.1)
       activerecord (>= 5.2.0, < 7.1)
       activesupport (>= 5.2.0, < 7.1)

--- a/lib/elasticity/base_document.rb
+++ b/lib/elasticity/base_document.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Elasticity
   class BaseDocument
     include ::ActiveModel::Model

--- a/lib/elasticity/bulk.rb
+++ b/lib/elasticity/bulk.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Elasticity
   class Bulk
     def initialize(client)

--- a/lib/elasticity/config.rb
+++ b/lib/elasticity/config.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Elasticity
   class Config
     def client=(client)

--- a/lib/elasticity/document.rb
+++ b/lib/elasticity/document.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Elasticity
   class Document < BaseDocument
     IndexMapper.set_delegates(singleton_class, :mapper)

--- a/lib/elasticity/index_config.rb
+++ b/lib/elasticity/index_config.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Elasticity
   class IndexConfig
     class SubclassError < StandardError; end

--- a/lib/elasticity/index_mapper.rb
+++ b/lib/elasticity/index_mapper.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Elasticity
   class IndexMapper
     def self.set_delegates(obj, to)

--- a/lib/elasticity/instrumented_client.rb
+++ b/lib/elasticity/instrumented_client.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Elasticity
   class InstrumentedClient
     INDICES_METHODS = %w(exists create delete get_settings get_mapping flush refresh get_alias get_aliases put_alias delete_alias exists_alias update_aliases)

--- a/lib/elasticity/log_subscriber.rb
+++ b/lib/elasticity/log_subscriber.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "active_support/subscriber"
 require "active_support/log_subscriber"
 

--- a/lib/elasticity/multi_search.rb
+++ b/lib/elasticity/multi_search.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Elasticity
   class MultiSearch
     def initialize(msearch_args = {})

--- a/lib/elasticity/multi_search_response_parser.rb
+++ b/lib/elasticity/multi_search_response_parser.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Elasticity
   class MultiSearchResponseParser
     class UnknownError < StandardError; end

--- a/lib/elasticity/railtie.rb
+++ b/lib/elasticity/railtie.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "elasticity/log_subscriber"
 
 module Elasticity

--- a/lib/elasticity/search.rb
+++ b/lib/elasticity/search.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Elasticity
   module Search
     def self.build(client, index_name, document_types, body, search_args = {})

--- a/lib/elasticity/segmented_document.rb
+++ b/lib/elasticity/segmented_document.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Elasticity
   class SegmentedDocument < BaseDocument
     # Creates a new segment which behaves almost the same as a Document class dynamically

--- a/lib/elasticity/strategies.rb
+++ b/lib/elasticity/strategies.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Elasticity
   module Strategies
     class IndexError < StandardError

--- a/lib/elasticity/strategies/alias_index.rb
+++ b/lib/elasticity/strategies/alias_index.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Elasticity
   module Strategies
     # This strategy keeps two aliases that might be mapped to the same index or different index, allowing

--- a/lib/elasticity/strategies/single_index.rb
+++ b/lib/elasticity/strategies/single_index.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Elasticity
   module Strategies
     class SingleIndex

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = "1.0.1.jhumphreys"
+  VERSION = "1.0.1"
 end

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Elasticity
   VERSION = "1.0.0"
 end

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = "1.0.0"
+  VERSION = "1.0.1.jhumphreys"
 end

--- a/spec/functional/persistence_spec.rb
+++ b/spec/functional/persistence_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Persistence", elasticsearch: true do
   def random_birthdate
     Time.at(0.0 + rand * (Time.now.to_f - 0.0.to_f))

--- a/spec/rspec_config.rb
+++ b/spec/rspec_config.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "simplecov"
 require "oj"
 require "elasticity"

--- a/spec/units/document_spec.rb
+++ b/spec/units/document_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "elasticity/search"
 
 RSpec.describe Elasticity::Document do

--- a/spec/units/index_config_spec.rb
+++ b/spec/units/index_config_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "elasticity/index_config"
 
 RSpec.describe Elasticity::IndexConfig do

--- a/spec/units/index_mapper_spec.rb
+++ b/spec/units/index_mapper_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "elasticity/index_mapper"
 
 RSpec.describe Elasticity::IndexMapper do

--- a/spec/units/multi_search_response_parser_spec.rb
+++ b/spec/units/multi_search_response_parser_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "elasticity/multi_search_response_parser"
 
 RSpec.describe Elasticity::MultiSearchResponseParser do

--- a/spec/units/multi_search_spec.rb
+++ b/spec/units/multi_search_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "elasticity/search"
 require "elasticity/multi_search"
 

--- a/spec/units/search_spec.rb
+++ b/spec/units/search_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "elasticity/search"
 
 RSpec.describe "Search" do

--- a/spec/units/strategies/alias_index_spec.rb
+++ b/spec/units/strategies/alias_index_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Elasticity::Strategies::AliasIndex, elasticsearch: true do
   subject do
     described_class.new(Elasticity.config.client, "test_index_name", "document")

--- a/spec/units/strategies/single_index_spec.rb
+++ b/spec/units/strategies/single_index_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Elasticity::Strategies::SingleIndex, elasticsearch: true do
   subject do
     described_class.new(Elasticity.config.client, "test_index_name", "document")


### PR DESCRIPTION
Jira story link: [MOFONETNAV-372]

We ran into an issue with version 1.0.0 where some classes, like `LogSubscriber`, are mutating strings. We'll wait to update these `frozen_string_literal` until the next release so we can isolate the changes.

### Changed
- Revert the additional `frozen_string_literal` updates in 1.0.0 due to some issues with some classes. We'll update these in a separate release to isolate the problem.

[MOFONETNAV-372]: https://doximity.atlassian.net/browse/MOFONETNAV-372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ