### PR TITLE
Update `doximity` s3 bucket urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://s3.amazonaws.com/doximity/logos/elasticity-logotype.svg" width="35%">
+<img src="https://dox-public-assets.s3.amazonaws.com/doximity/logos/elasticity-logotype.svg" width="35%">
 
 ---
 


### PR DESCRIPTION
Jira link: [APPSEC-663](https://doximity.atlassian.net/browse/APPSEC-663)

## Overview

We are migrating s3 buckets away from our `dox-legacy` aws account ahead of closing that account.

This PR updates references to that bucket, replacing them with a new bucket `dox-public-assets`. All the content has been migrated to this new bucket under the `/doximity` subdirectory, so the URLs are identical except for a new hostname prefix.

## QA Instructions

This should require no QA. We can spot-check the updated URLs to make sure they load in a browser.

This upgrade was automatically generated with `sourcegraph`.

[_Created by Sourcegraph batch change `jgran/doximity-s3`._](https://sourcegraph.build.dox.pub/users/jgran/batch-changes/doximity-s3)